### PR TITLE
Improve MySQL importer validation and cursor handling

### DIFF
--- a/src/qcc/data_ingestion/__init__.py
+++ b/src/qcc/data_ingestion/__init__.py
@@ -1,0 +1,17 @@
+"""Utilities for importing quality control data from MySQL."""
+
+from .mysql_config import MySQLConfig
+from .mysql_importer import (
+    DEFAULT_TAG_PROMPT_TABLES,
+    TableImporter,
+    import_tag_prompt_deployment_tables,
+    mysql_connection,
+)
+
+__all__ = [
+    "MySQLConfig",
+    "TableImporter",
+    "mysql_connection",
+    "DEFAULT_TAG_PROMPT_TABLES",
+    "import_tag_prompt_deployment_tables",
+]

--- a/src/qcc/data_ingestion/mysql_config.py
+++ b/src/qcc/data_ingestion/mysql_config.py
@@ -1,0 +1,112 @@
+"""Configuration helpers for connecting to a MySQL database."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+
+@dataclass(frozen=True)
+class MySQLConfig:
+    """Connection parameters required for accessing a MySQL database.
+
+    Parameters
+    ----------
+    host:
+        Hostname or IP address of the MySQL server.
+    user:
+        Username used to authenticate with the database.
+    password:
+        Password used to authenticate with the database.
+    database:
+        Name of the database to connect to.
+    port:
+        TCP port where the MySQL server is listening. Defaults to 3306.
+    charset:
+        Optional character set to use for the connection. UTF-8 is used by
+        default when not provided.
+    use_pure:
+        When ``True``, ``mysql.connector`` will use the Python implementation
+        instead of the C extension. Defaults to ``False`` to automatically pick
+        the optimal implementation.
+    """
+
+    host: str
+    user: str
+    password: str
+    database: str
+    port: int = 3306
+    charset: Optional[str] = None
+    use_pure: bool = False
+
+    @classmethod
+    def from_env(cls, prefix: str = "MYSQL") -> "MySQLConfig":
+        """Build a configuration object using environment variables.
+
+        Parameters
+        ----------
+        prefix:
+            Prefix used in the environment variable names. For example, with
+            the default prefix of ``MYSQL`` the variables ``MYSQL_HOST``,
+            ``MYSQL_USER`` and so on are read.
+
+        Returns
+        -------
+        MySQLConfig
+            A populated configuration object.
+
+        Raises
+        ------
+        ValueError
+            If any required variables are missing.
+        """
+
+        env_map = {
+            "host": os.getenv(f"{prefix}_HOST"),
+            "user": os.getenv(f"{prefix}_USER"),
+            "password": os.getenv(f"{prefix}_PASSWORD"),
+            "database": os.getenv(f"{prefix}_DATABASE"),
+            "port": os.getenv(f"{prefix}_PORT"),
+            "charset": os.getenv(f"{prefix}_CHARSET"),
+            "use_pure": os.getenv(f"{prefix}_USE_PURE"),
+        }
+
+        missing = [key for key in ("host", "user", "password", "database") if not env_map[key]]
+        if missing:
+            raise ValueError(
+                "Missing required environment variables for MySQL configuration: "
+                + ", ".join(f"{prefix}_{name.upper()}" for name in missing)
+            )
+
+        port_value = int(env_map["port"]) if env_map["port"] else 3306
+        use_pure_value = (
+            env_map["use_pure"].strip().lower() in {"1", "true", "yes"}
+            if env_map["use_pure"]
+            else False
+        )
+
+        return cls(
+            host=env_map["host"],
+            user=env_map["user"],
+            password=env_map["password"],
+            database=env_map["database"],
+            port=port_value,
+            charset=env_map["charset"],
+            use_pure=use_pure_value,
+        )
+
+    def as_connector_kwargs(self) -> Dict[str, object]:
+        """Return keyword arguments compatible with ``mysql.connector.connect``."""
+
+        kwargs: Dict[str, object] = {
+            "host": self.host,
+            "user": self.user,
+            "password": self.password,
+            "database": self.database,
+            "port": self.port,
+            "use_pure": self.use_pure,
+        }
+        if self.charset:
+            kwargs["charset"] = self.charset
+        return kwargs

--- a/src/qcc/data_ingestion/mysql_importer.py
+++ b/src/qcc/data_ingestion/mysql_importer.py
@@ -1,0 +1,97 @@
+"""MySQL data import helpers."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+import re
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence
+
+import mysql.connector
+
+from .mysql_config import MySQLConfig
+
+DEFAULT_TAG_PROMPT_TABLES: Sequence[str] = (
+    "tag_prompt_deployment_answers",
+    "tag_prompt_deployment_confidences",
+)
+
+
+@contextmanager
+def mysql_connection(config: MySQLConfig):
+    """Context manager that yields an open MySQL connection."""
+
+    connection = mysql.connector.connect(**config.as_connector_kwargs())
+    try:
+        yield connection
+    finally:
+        connection.close()
+
+
+class TableImporter:
+    """Utility class that reads rows from MySQL tables into dictionaries."""
+
+    def __init__(self, config: MySQLConfig):
+        self._config = config
+
+    def fetch_table(self, table_name: str, limit: Optional[int] = None) -> List[Dict[str, Any]]:
+        """Return the full contents of a table as a list of dictionaries.
+
+        Parameters
+        ----------
+        table_name:
+            The table to read from. The name is validated to contain only
+            alphanumeric characters and underscores to prevent SQL injection.
+        limit:
+            Optionally restrict the number of rows returned from the table.
+        """
+
+        if not table_name or not re.fullmatch(r"[A-Za-z0-9_]+", table_name):
+            raise ValueError(f"Invalid table name: {table_name!r}")
+
+        query = f"SELECT * FROM `{table_name}`"
+        params: Optional[Sequence[object]] = None
+        if limit is not None:
+            limit_value = int(limit)
+            if limit_value < 0:
+                raise ValueError("limit must be non-negative")
+            query += " LIMIT %s"
+            params = (limit_value,)
+
+        with mysql_connection(self._config) as connection:
+            cursor = connection.cursor(dictionary=True)
+            try:
+                cursor.execute(query, params)
+                rows = cursor.fetchall()
+            finally:
+                cursor.close()
+
+        return rows
+
+    def import_tables(
+        self,
+        table_names: Iterable[str],
+        limit: Optional[int] = None,
+    ) -> Mapping[str, List[Dict[str, Any]]]:
+        """Fetch multiple tables and return a mapping of table name to rows."""
+
+        data: MutableMapping[str, List[Dict[str, Any]]] = {}
+        for name in table_names:
+            data[name] = self.fetch_table(name, limit=limit)
+        return data
+
+
+def import_tag_prompt_deployment_tables(
+    config: MySQLConfig,
+    tables: Sequence[str] = DEFAULT_TAG_PROMPT_TABLES,
+    limit: Optional[int] = None,
+) -> Mapping[str, List[Dict[str, Any]]]:
+    """Import tag prompt deployment data from the configured MySQL database.
+
+    The default ``tables`` value matches the schema shared in the quality control
+    dashboards: a table that stores answers and a table that stores confidence
+    levels. The function can be customised by passing a different sequence of
+    table names.
+    """
+
+    importer = TableImporter(config)
+    return importer.import_tables(tables, limit=limit)


### PR DESCRIPTION
## Summary
- ensure MySQL table names and LIMIT values are validated before querying
- fetch rows using mysql-connector dictionary cursors to avoid manual column mapping
- keep configuration imports ordered for consistency

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68e58c1498108333a6204109aa79e7c2