### PR TITLE
Handle missing MySQL connector gracefully

### DIFF
--- a/src/qcc/data_ingestion/__init__.py
+++ b/src/qcc/data_ingestion/__init__.py
@@ -7,6 +7,7 @@ from .mysql_importer import (
     import_tag_prompt_deployment_tables,
     mysql_connection,
 )
+from .tag_prompt_dataset import TagPromptDeploymentDataset
 
 __all__ = [
     "MySQLConfig",
@@ -14,4 +15,5 @@ __all__ = [
     "mysql_connection",
     "DEFAULT_TAG_PROMPT_TABLES",
     "import_tag_prompt_deployment_tables",
+    "TagPromptDeploymentDataset",
 ]

--- a/src/qcc/data_ingestion/mysql_importer.py
+++ b/src/qcc/data_ingestion/mysql_importer.py
@@ -6,7 +6,12 @@ from contextlib import contextmanager
 import re
 from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence
 
-import mysql.connector
+try:  # pragma: no cover - dependency availability is environment specific
+    import mysql.connector  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - handled at runtime
+    mysql_connector = None
+else:  # pragma: no cover - trivial alias
+    mysql_connector = mysql.connector
 
 from .mysql_config import MySQLConfig
 
@@ -20,7 +25,12 @@ DEFAULT_TAG_PROMPT_TABLES: Sequence[str] = (
 def mysql_connection(config: MySQLConfig):
     """Context manager that yields an open MySQL connection."""
 
-    connection = mysql.connector.connect(**config.as_connector_kwargs())
+    if mysql_connector is None:
+        raise ModuleNotFoundError(
+            "mysql.connector is required to establish a MySQL connection. Install the 'mysql-connector-python' package."
+        )
+
+    connection = mysql_connector.connect(**config.as_connector_kwargs())
     try:
         yield connection
     finally:

--- a/src/qcc/data_ingestion/tag_prompt_dataset.py
+++ b/src/qcc/data_ingestion/tag_prompt_dataset.py
@@ -1,0 +1,212 @@
+"""Transform raw MySQL tag prompt tables into domain objects."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence
+
+from qcc.domain.enums import TagValue
+from qcc.domain.tagassignment import TagAssignment
+from qcc.domain.tagger import Tagger
+
+from .mysql_importer import DEFAULT_TAG_PROMPT_TABLES
+
+
+_TAGGER_KEYS = ("tagger_id", "worker_id", "user_id")
+_COMMENT_KEYS = ("comment_id", "item_id", "document_id")
+_CHARACTERISTIC_KEYS = (
+    "characteristic_id",
+    "tag_prompt_deployment_characteristic_id",
+    "characteristic_slug",
+)
+_VALUE_KEYS = ("value", "response", "answer", "label")
+_TIMESTAMP_KEYS = (
+    "tagged_at",
+    "created_at",
+    "updated_at",
+    "completed_at",
+    "timestamp",
+)
+
+
+@dataclass(frozen=True)
+class TagPromptDeploymentDataset:
+    """Collection of domain objects derived from tag prompt deployment tables."""
+
+    assignments: List[TagAssignment]
+    taggers: List[Tagger]
+
+    @classmethod
+    def from_mysql_tables(
+        cls,
+        tables: Mapping[str, Sequence[Mapping[str, Any]]],
+        *,
+        answers_table: Optional[str] = None,
+    ) -> "TagPromptDeploymentDataset":
+        """Create a dataset from the raw tables fetched via :mod:`mysql_importer`.
+
+        Parameters
+        ----------
+        tables:
+            Mapping of table name to an iterable of row dictionaries. This is the
+            structure returned by :func:`import_tag_prompt_deployment_tables`.
+        answers_table:
+            Optional override for which table contains the assignment rows. When
+            omitted, the first table in :data:`DEFAULT_TAG_PROMPT_TABLES` that is
+            present in *tables* is used.
+        """
+
+        if not tables:
+            return cls(assignments=[], taggers=[])
+
+        source_table = _select_answers_table(tables, answers_table)
+        rows = tables.get(source_table, [])
+
+        assignments = []
+        for row in rows:
+            assignment = _row_to_assignment(row)
+            if assignment is not None:
+                assignments.append(assignment)
+
+        taggers = _group_assignments_by_tagger(assignments)
+        return cls(assignments=assignments, taggers=taggers)
+
+    def as_domain_dict(self) -> Dict[str, Any]:
+        """Return a mapping resembling the CSV adapter contract."""
+
+        return {
+            "assignments": self.assignments,
+            "taggers": self.taggers,
+            "comments": [],
+            "prompts": [],
+            "characteristics": [],
+        }
+
+
+def _select_answers_table(
+    tables: Mapping[str, Sequence[Mapping[str, Any]]],
+    answers_table: Optional[str],
+) -> str:
+    if answers_table and answers_table in tables:
+        return answers_table
+
+    for name in DEFAULT_TAG_PROMPT_TABLES:
+        if name in tables:
+            return name
+
+    # Fall back to deterministic selection for predictable behaviour in tests.
+    return next(iter(tables.keys()))
+
+
+def _row_to_assignment(row: Mapping[str, Any]) -> Optional[TagAssignment]:
+    try:
+        tagger_id = _extract_first(row, _TAGGER_KEYS)
+        comment_id = _extract_first(row, _COMMENT_KEYS)
+        characteristic_id = _extract_first(row, _CHARACTERISTIC_KEYS)
+        value_raw = _extract_first(row, _VALUE_KEYS)
+        timestamp_raw = _extract_first(row, _TIMESTAMP_KEYS)
+    except KeyError:
+        return None
+
+    if not all([tagger_id, comment_id, characteristic_id, value_raw, timestamp_raw]):
+        return None
+
+    try:
+        tag_value = _parse_tag_value(value_raw)
+        timestamp = _parse_timestamp(timestamp_raw)
+    except ValueError:
+        return None
+
+    return TagAssignment(
+        tagger_id=str(tagger_id),
+        comment_id=str(comment_id),
+        characteristic_id=str(characteristic_id),
+        value=tag_value,
+        timestamp=timestamp,
+    )
+
+
+def _extract_first(row: Mapping[str, Any], keys: Iterable[str]) -> Any:
+    for key in keys:
+        if key in row:
+            return row[key]
+    raise KeyError(keys)
+
+
+def _parse_tag_value(value: Any) -> TagValue:
+    if isinstance(value, TagValue):
+        return value
+
+    if value is None:
+        raise ValueError("Tag value is required")
+
+    value_str = str(value).strip()
+    if not value_str:
+        raise ValueError("Tag value cannot be empty")
+
+    normalized = value_str.upper()
+
+    alias_map = {
+        "Y": TagValue.YES,
+        "YES": TagValue.YES,
+        "TRUE": TagValue.YES,
+        "T": TagValue.YES,
+        "N": TagValue.NO,
+        "NO": TagValue.NO,
+        "FALSE": TagValue.NO,
+        "F": TagValue.NO,
+        "NA": TagValue.NA,
+        "N/A": TagValue.NA,
+        "UNKNOWN": TagValue.NA,
+        "UNCERTAIN": TagValue.UNCERTAIN,
+        "SKIP": TagValue.SKIP,
+    }
+
+    if normalized in alias_map:
+        return alias_map[normalized]
+
+    try:
+        return TagValue(normalized)
+    except ValueError:
+        pass
+
+    try:
+        return TagValue[value_str]
+    except KeyError as exc:
+        raise ValueError(f"Unrecognised tag value: {value_str!r}") from exc
+
+
+def _parse_timestamp(value: Any) -> datetime:
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+
+    if value is None:
+        raise ValueError("Timestamp is required")
+
+    if isinstance(value, (int, float)):
+        return datetime.fromtimestamp(value, tz=timezone.utc)
+
+    value_str = str(value).strip()
+    if not value_str:
+        raise ValueError("Timestamp cannot be empty")
+
+    iso_candidate = value_str.replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(iso_candidate)
+    except ValueError as exc:
+        raise ValueError(f"Invalid timestamp: {value_str!r}") from exc
+
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+
+def _group_assignments_by_tagger(assignments: Sequence[TagAssignment]) -> List[Tagger]:
+    grouped: MutableMapping[str, List[TagAssignment]] = {}
+    for assignment in assignments:
+        grouped.setdefault(assignment.tagger_id, []).append(assignment)
+
+    taggers: List[Tagger] = []
+    for tagger_id in sorted(grouped.keys()):
+        tag_assignments = sorted(grouped[tagger_id], key=lambda a: a.timestamp)
+        taggers.append(Tagger(id=tagger_id, tagassignments=tag_assignments))
+    return taggers

--- a/src/qcc/domain/prompt.py
+++ b/src/qcc/domain/prompt.py
@@ -1,0 +1,19 @@
+"""Prompt domain model for crowd labeling quality control."""
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class Prompt:
+    """A prompt groups related comments within a deployment."""
+
+    id: str
+    text: str
+    description: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if not self.id:
+            raise ValueError("prompt id cannot be empty")
+        if not self.text:
+            raise ValueError("prompt text cannot be empty")

--- a/tests/cli/test_run_analysis.py
+++ b/tests/cli/test_run_analysis.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+import pytest
+
+from qcc.cli.main import run_analysis
+from qcc.config.schema import QCCConfig
+
+
+def _make_db_config(dsn: str) -> QCCConfig:
+    return QCCConfig.model_validate({
+        "input": {"format": "db", "path": dsn},
+        "output": {"directory": "reports", "format": "json"},
+    })
+
+
+def test_run_analysis_raises_value_error_when_mysql_connector_missing(monkeypatch, tmp_path):
+    config = _make_db_config("mysql://user:pass@localhost/database")
+
+    def _raise_missing_connector(_config):
+        raise ModuleNotFoundError("mysql connector missing")
+
+    monkeypatch.setattr(
+        "qcc.cli.main.import_tag_prompt_deployment_tables",
+        _raise_missing_connector,
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        run_analysis(
+            input_path=Path("input.csv"),
+            output_dir=tmp_path,
+            config=config,
+        )
+
+    assert "mysql-connector-python" in str(excinfo.value)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+"""Pytest configuration helpers."""
+
+import sys
+from pathlib import Path
+
+
+# Ensure the ``src`` directory is importable without installing the package.
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+SRC_PATH = PROJECT_ROOT / "src"
+if SRC_PATH.exists():
+    sys.path.insert(0, str(SRC_PATH))

--- a/tests/data_ingestion/test_mysql_config.py
+++ b/tests/data_ingestion/test_mysql_config.py
@@ -1,0 +1,30 @@
+import pytest
+
+from qcc.data_ingestion import MySQLConfig
+
+
+def test_from_dsn_parses_basic_components():
+    config = MySQLConfig.from_dsn("mysql://user:pass@example.com:3307/database?charset=utf8mb4&use_pure=1")
+
+    assert config.host == "example.com"
+    assert config.user == "user"
+    assert config.password == "pass"
+    assert config.database == "database"
+    assert config.port == 3307
+    assert config.charset == "utf8mb4"
+    assert config.use_pure is True
+
+
+@pytest.mark.parametrize(
+    "dsn",
+    [
+        "",
+        "postgres://user:pass@host/db",
+        "mysql://@host/db",
+        "mysql://user@/db",
+        "mysql://user:pass@host",
+    ],
+)
+def test_from_dsn_invalid_inputs(dsn):
+    with pytest.raises(ValueError):
+        MySQLConfig.from_dsn(dsn)

--- a/tests/data_ingestion/test_tag_prompt_dataset.py
+++ b/tests/data_ingestion/test_tag_prompt_dataset.py
@@ -1,0 +1,57 @@
+from datetime import datetime, timezone
+
+from qcc.data_ingestion import TagPromptDeploymentDataset, DEFAULT_TAG_PROMPT_TABLES
+from qcc.domain.enums import TagValue
+
+
+def _make_rows():
+    answers_table = DEFAULT_TAG_PROMPT_TABLES[0]
+    rows = [
+        {
+            "tagger_id": "worker-1",
+            "comment_id": "comment-1",
+            "characteristic_id": "char-a",
+            "value": "YES",
+            "created_at": "2024-01-01T00:00:00Z",
+        },
+        {
+            "user_id": "worker-1",
+            "item_id": "comment-2",
+            "tag_prompt_deployment_characteristic_id": "char-a",
+            "response": "no",
+            "updated_at": datetime(2024, 1, 1, 0, 5, tzinfo=timezone.utc),
+        },
+        {
+            # Missing timestamp -> ignored
+            "tagger_id": "worker-2",
+            "comment_id": "comment-3",
+            "characteristic_id": "char-b",
+            "value": "YES",
+        },
+    ]
+    return answers_table, rows
+
+
+def test_dataset_groups_assignments_by_tagger():
+    table_name, rows = _make_rows()
+    dataset = TagPromptDeploymentDataset.from_mysql_tables({table_name: rows})
+
+    assert len(dataset.assignments) == 2
+    assert {assignment.comment_id for assignment in dataset.assignments} == {"comment-1", "comment-2"}
+
+    assert len(dataset.taggers) == 1
+    tagger = dataset.taggers[0]
+    assert tagger.id == "worker-1"
+    assert len(tagger.tagassignments) == 2
+    assert tagger.tagassignments[0].value is TagValue.YES
+    assert tagger.tagassignments[1].value is TagValue.NO
+
+
+def test_as_domain_dict_structure():
+    table_name, rows = _make_rows()
+    dataset = TagPromptDeploymentDataset.from_mysql_tables({table_name: rows})
+
+    domain = dataset.as_domain_dict()
+    assert set(domain.keys()) == {"assignments", "taggers", "comments", "prompts", "characteristics"}
+    assert domain["assignments"] == dataset.assignments
+    assert domain["taggers"] == dataset.taggers


### PR DESCRIPTION
## Summary
- raise a user-friendly error from the CLI analysis pipeline when the optional MySQL connector dependency is absent
- add a lightweight Prompt domain model so CLI imports succeed during tests
- cover the new failure mode with a regression test for `run_analysis`

## Testing
- pytest tests/data_ingestion/test_mysql_config.py tests/data_ingestion/test_tag_prompt_dataset.py tests/cli/test_run_analysis.py

------
https://chatgpt.com/codex/tasks/task_e_68f6b6ecc6e08333b859dec5ec61dc23