### PR TITLE
Refactor CLI to delegate summary generation to reporting framework

### DIFF
--- a/src/qcc/cli/main.py
+++ b/src/qcc/cli/main.py
@@ -4,20 +4,17 @@ import argparse
 import json
 import os
 import sys
-from collections import defaultdict
 from pathlib import Path
 from typing import Dict, Optional, Tuple
 from urllib.parse import parse_qs, urlparse
 
 import yaml
 
-from qcc.config.schema import QCCConfig, InputConfig
+from qcc.config.schema import InputConfig, QCCConfig
 from qcc.data_ingestion.mysql_config import MySQLConfig
 from qcc.io.csv_adapter import CSVAdapter
 from qcc.io.db_adapter import DBAdapter
-from qcc.metrics.speed_strategy import LogTrimTaggingSpeed
-from qcc.metrics.pattern_strategy import HorizontalPatternDetection
-from qcc.metrics.utils.pattern import PatternCollection
+from qcc.reports.tagger_performance import TaggerPerformanceReport
 
 
 def main() -> int:
@@ -236,9 +233,14 @@ def run_analysis(
     # Read input data
     domain_objects, input_source = _read_domain_objects(input_path, config.input)
     
-    # TODO: Implement actual analysis logic
-    # For now, return a simple summary
-    summary = _build_summary(domain_objects)
+    assignments = list(domain_objects.get("assignments", []) or [])
+    taggers = list(domain_objects.get("taggers", []) or [])
+    characteristics = list(domain_objects.get("characteristics", []) or [])
+
+    report = TaggerPerformanceReport(assignments)
+    summary = report.generate_summary_report(taggers, characteristics)
+
+    report.export_to_csv(summary, output_dir / "summary.csv")
 
     result = {
         "input_source": input_source,
@@ -262,188 +264,6 @@ def write_summary(result: dict, output_dir: Path) -> None:
     with open(summary_path, 'w', encoding='utf-8') as f:
         json.dump(result, f, indent=2, default=str)
 
-    summary = result.get("summary", {})
-    _write_summary_csv(summary, output_dir / "summary.csv")
-
-
-def _build_summary(domain_objects: Dict[str, object]) -> Dict[str, object]:
-    """Aggregate a summary report containing tagging speed and pattern metrics."""
-
-    taggers = list(domain_objects.get("taggers", []) or [])
-
-    speed_strategy = LogTrimTaggingSpeed()
-    pattern_strategy = HorizontalPatternDetection()
-    tracked_patterns = PatternCollection.return_all_patterns()
-
-    per_tagger_speed: List[Dict[str, object]] = []
-    seconds_samples = []
-    per_tagger_patterns: List[Dict[str, object]] = []
-    aggregate_pattern_counts: Dict[str, int] = defaultdict(int)
-    taggers_with_patterns = 0
-
-    for tagger in taggers:
-        pattern_counts = pattern_strategy.analyze(tagger)
-        positive_patterns = {
-            pattern: count
-            for pattern, count in (pattern_counts or {}).items()
-            if count > 0
-        }
-        if positive_patterns:
-            taggers_with_patterns += 1
-            per_tagger_patterns.append(
-                {
-                    "tagger_id": str(tagger.id),
-                    "patterns": dict(sorted(positive_patterns.items())),
-                }
-            )
-            for pattern, count in positive_patterns.items():
-                aggregate_pattern_counts[pattern] += count
-
-        assignments_with_time = [
-            assignment
-            for assignment in (tagger.tagassignments or [])
-            if getattr(assignment, "timestamp", None) is not None
-        ]
-
-        if len(assignments_with_time) < 2:
-            continue
-
-        mean_log2 = speed_strategy.speed_log2(tagger)
-        if not math.isfinite(mean_log2):
-            continue
-
-        seconds_value = speed_strategy.seconds_per_tag(mean_log2)
-        if not math.isfinite(seconds_value):
-            continue
-
-        per_tagger_speed.append(
-            {
-                "tagger_id": str(tagger.id),
-                "mean_log2": mean_log2,
-                "seconds_per_tag": seconds_value,
-                "timestamped_assignments": len(assignments_with_time),
-            }
-        )
-        if seconds_value > 0:
-            seconds_samples.append(seconds_value)
-
-    if seconds_samples:
-        mean_seconds = mean(seconds_samples)
-        median_seconds = median(seconds_samples)
-        min_seconds = min(seconds_samples)
-        max_seconds = max(seconds_samples)
-    else:
-        mean_seconds = 0.0
-        median_seconds = 0.0
-        min_seconds = 0.0
-        max_seconds = 0.0
-
-    summary_seconds = {
-        "mean": mean_seconds,
-        "median": median_seconds,
-        "min": min_seconds,
-        "max": max_seconds,
-    }
-
-    pattern_summary = {
-        "strategy": "HorizontalPatternDetection",
-        "patterns_tracked": tracked_patterns,
-        "taggers_with_patterns": taggers_with_patterns,
-        "aggregate_counts": dict(sorted(aggregate_pattern_counts.items())),
-        "per_tagger": per_tagger_patterns,
-    }
-
-    return {
-        "tagger_speed": {
-            "strategy": "LogTrimTaggingSpeed",
-            "taggers_with_speed": len(per_tagger_speed),
-            "seconds_per_tag": summary_seconds,
-            "per_tagger": per_tagger_speed,
-        },
-        "pattern_detection": pattern_summary,
-    }
-
-
-def _write_summary_csv(summary: Dict[str, object], csv_path: Path) -> None:
-    """Write a CSV representation of the summary report using the reporter."""
-
-        seconds_section = tagger_speed.get("seconds_per_tag", {}) or {}
-        for metric_name, metric_value in seconds_section.items():
-            rows.append(
-                {
-                    "Strategy": "Tagger Speed",
-                    "user_id": "aggregate",
-                    "Metric": f"seconds_per_tag_{metric_name}",
-                    "Value": _stringify_csv_value(metric_value),
-                }
-            )
-
-        for tagger_entry in tagger_speed.get("per_tagger", []) or []:
-            tagger_id = str(tagger_entry.get("tagger_id", ""))
-            for metric_name in ("mean_log2", "seconds_per_tag", "timestamped_assignments"):
-                if metric_name in tagger_entry:
-                    rows.append(
-                        {
-                            "Strategy": "Tagger Speed",
-                            "user_id": tagger_id,
-                            "Metric": metric_name,
-                            "Value": _stringify_csv_value(tagger_entry[metric_name]),
-                        }
-                    )
-
-    pattern_summary = summary.get("pattern_detection", {}) if summary else {}
-    if pattern_summary:
-        rows.append(
-            {
-                "Strategy": "Pattern Detection",
-                "user_id": "aggregate",
-                "Metric": "taggers_with_patterns",
-                "Value": _stringify_csv_value(
-                    pattern_summary.get("taggers_with_patterns", 0)
-                ),
-            }
-        )
-
-        aggregate_counts = pattern_summary.get("aggregate_counts", {}) or {}
-        for pattern, count in aggregate_counts.items():
-            rows.append(
-                {
-                    "Strategy": "Pattern Detection",
-                    "user_id": "aggregate",
-                    "Metric": f"pattern_{pattern}",
-                    "Value": _stringify_csv_value(count),
-                }
-            )
-
-        for entry in pattern_summary.get("per_tagger", []) or []:
-            tagger_id = str(entry.get("tagger_id", ""))
-            for pattern, count in (entry.get("patterns") or {}).items():
-                rows.append(
-                    {
-                        "Strategy": "Pattern Detection",
-                        "user_id": tagger_id,
-                        "Metric": f"pattern_{pattern}",
-                        "Value": _stringify_csv_value(count),
-                    }
-                )
-
-    if not rows:
-        rows.append({"Strategy": "Tagger Speed", "user_id": "aggregate", "Metric": "", "Value": ""})
-
-    with open(csv_path, "w", newline="", encoding="utf-8") as csv_file:
-        writer = csv.DictWriter(csv_file, fieldnames=["Strategy", "user_id", "Metric", "Value"])
-        writer.writeheader()
-        writer.writerows(rows)
-
-
-def _stringify_csv_value(value: object) -> str:
-    """Convert a summary value into a string suitable for CSV output."""
-
-    if value is None:
-        return ""
-    if isinstance(value, float):
-        return f"{value:.6f}".rstrip("0").rstrip(".") if not value.is_integer() else str(int(value))
-    return str(value)
 def _read_domain_objects(
     input_path: Optional[Path], input_config: InputConfig
 ) -> Tuple[dict, str]:

--- a/tests/test_db_adapter.py
+++ b/tests/test_db_adapter.py
@@ -6,7 +6,6 @@ import pytest
 
 import csv
 
-from qcc.cli.main import _build_summary, _write_summary_csv
 from qcc.data_ingestion.mysql_config import MySQLConfig
 from qcc.data_ingestion.mysql_importer import DEFAULT_TAG_PROMPT_TABLES
 from qcc.io.db_adapter import DBAdapter
@@ -14,6 +13,7 @@ from qcc.domain.enums import TagValue
 from qcc.domain.comment import Comment
 from qcc.domain.tagassignment import TagAssignment
 from qcc.domain.tagger import Tagger
+from qcc.reports.tagger_performance import TaggerPerformanceReport
 
 
 class FakeImporter:
@@ -147,7 +147,11 @@ def test_db_adapter_merges_answers_with_tags():
     assert deployments["5"]["question_id"] == "7"
     assert deployments["5"]["prompt_label"] == "Spam?"
 
-    summary = _build_summary(domain_objects)
+    report = TaggerPerformanceReport(domain_objects["assignments"])
+    summary = report.generate_summary_report(
+        domain_objects.get("taggers", []),
+        domain_objects.get("characteristics", []),
+    )
     assert "tagger_speed" in summary
     speed_summary = summary["tagger_speed"]
     assert speed_summary["strategy"] == "LogTrimTaggingSpeed"
@@ -263,7 +267,11 @@ def test_summary_includes_speed_metrics():
         "questions": [],
     }
 
-    summary = _build_summary(domain_objects)
+    report = TaggerPerformanceReport(domain_objects["assignments"])
+    summary = report.generate_summary_report(
+        domain_objects.get("taggers", []),
+        domain_objects.get("characteristics", []),
+    )
 
     speed_metrics = summary["tagger_speed"]
     assert speed_metrics["taggers_with_speed"] == 1
@@ -329,7 +337,11 @@ def test_summary_includes_pattern_metrics(tmp_path):
         "questions": [],
     }
 
-    summary = _build_summary(domain_objects)
+    report = TaggerPerformanceReport(domain_objects["assignments"])
+    summary = report.generate_summary_report(
+        domain_objects.get("taggers", []),
+        domain_objects.get("characteristics", []),
+    )
 
     pattern_summary = summary["pattern_detection"]
     assert pattern_summary["strategy"] == "HorizontalPatternDetection"
@@ -350,7 +362,7 @@ def test_summary_includes_pattern_metrics(tmp_path):
     assert per_tagger["42"]["patterns"] == {"YN": 2}
 
     csv_path = tmp_path / "summary.csv"
-    _write_summary_csv(summary, csv_path)
+    report.export_to_csv(summary, csv_path)
 
     with csv_path.open(newline="", encoding="utf-8") as fh:
         rows = list(csv.DictReader(fh))
@@ -358,16 +370,18 @@ def test_summary_includes_pattern_metrics(tmp_path):
     assert any(
         row["Strategy"] == "Pattern Detection"
         and row["user_id"] == "aggregate"
-        and row["Metric"] == "pattern_YN"
-        and row["Value"] == "2"
+        and row["Metric"] == "pattern_count"
+        and row["pattern_detected"] == "YN"
+        and row["pattern_value"] == "2"
         for row in rows
     )
 
     assert any(
         row["Strategy"] == "Pattern Detection"
         and row["user_id"] == "42"
-        and row["Metric"] == "pattern_YN"
-        and row["Value"] == "2"
+        and row["Metric"] == "pattern_count"
+        and row["pattern_detected"] == "YN"
+        and row["pattern_value"] == "2"
         for row in rows
     )
 


### PR DESCRIPTION
## Summary
- delegate the CLI summary generation to TaggerPerformanceReport and export CSV via the reporting framework
- update db adapter tests to exercise the reporter-backed summary and CSV layout

## Testing
- pytest tests/test_db_adapter.py

------
https://chatgpt.com/codex/tasks/task_e_690bbce19ae08333ba25f99de4d6e48e