### PR TITLE
Restore agreement strategy delegation

### DIFF
--- a/src/qcc/metrics/__init__.py
+++ b/src/qcc/metrics/__init__.py
@@ -1,0 +1,5 @@
+"""Metrics strategy and helper exports."""
+
+from .agreement import AgreementMetrics
+
+__all__ = ["AgreementMetrics"]

--- a/src/qcc/metrics/agreement.py
+++ b/src/qcc/metrics/agreement.py
@@ -61,6 +61,16 @@ class AgreementMetrics:
 
         return self._strategy.agreement_matrix(assignments, characteristic)
 
+    def per_tagger_metrics(
+        self,
+        assignments: Iterable[TagAssignment],
+        characteristic: Characteristic,
+        methods: Sequence[str],
+    ) -> dict[str, dict[str, float]]:
+        """Return agreement metrics averaged per tagger for the requested methods."""
+
+        return self._strategy.per_tagger_metrics(assignments, characteristic, methods)
+
     # ------------------------------------------------------------------
     # Utilities
     # ------------------------------------------------------------------

--- a/src/qcc/metrics/agreement.py
+++ b/src/qcc/metrics/agreement.py
@@ -1,0 +1,78 @@
+"""Agreement metric façade delegating to the strategy implementation."""
+
+from __future__ import annotations
+
+from typing import Iterable, Optional, Sequence
+
+from qcc.domain.characteristic import Characteristic
+from qcc.domain.tagassignment import TagAssignment
+from qcc.domain.tagger import Tagger
+
+from .agreement_strategy import LatestLabelPercentAgreement
+
+
+class AgreementMetrics:
+    """Expose agreement helpers backed by :class:`LatestLabelPercentAgreement`."""
+
+    def __init__(self, strategy: Optional[LatestLabelPercentAgreement] = None) -> None:
+        self._strategy = strategy or LatestLabelPercentAgreement()
+
+    @property
+    def strategy(self) -> LatestLabelPercentAgreement:
+        """Return the underlying agreement strategy instance."""
+
+        return self._strategy
+
+    # ------------------------------------------------------------------
+    # Public helpers
+    # ------------------------------------------------------------------
+    def percent_agreement(
+        self, assignments: Iterable[TagAssignment], characteristic: Characteristic
+    ) -> float:
+        """Return overall percent agreement across all raters."""
+
+        return self._strategy.percent_agreement(assignments, characteristic)
+
+    def cohens_kappa(
+        self, assignments: Iterable[TagAssignment], characteristic: Characteristic
+    ) -> float:
+        """Return Cohen's kappa averaged across tagger pairs."""
+
+        return self._strategy.cohens_kappa(assignments, characteristic)
+
+    def krippendorffs_alpha(
+        self, assignments: Iterable[TagAssignment], characteristic: Characteristic
+    ) -> Optional[float]:
+        """Return Krippendorff's alpha for the characteristic."""
+
+        return self._strategy.krippendorff_alpha(assignments, characteristic)
+
+    def pairwise_agreement(
+        self, tagger_a: Tagger, tagger_b: Tagger, characteristic: Characteristic
+    ) -> float:
+        """Return percent agreement for the two provided taggers."""
+
+        return self._strategy.pairwise(tagger_a, tagger_b, characteristic)
+
+    def agreement_matrix(
+        self, assignments: Iterable[TagAssignment], characteristic: Characteristic
+    ) -> dict[str, dict[str, float]]:
+        """Return the pairwise agreement matrix for all participating taggers."""
+
+        return self._strategy.agreement_matrix(assignments, characteristic)
+
+    # ------------------------------------------------------------------
+    # Utilities
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _filter_assignments_by_characteristic(
+        assignments: Iterable[TagAssignment], characteristic: Characteristic
+    ) -> Sequence[TagAssignment]:
+        """Return assignments that match ``characteristic``."""
+
+        characteristic_id = characteristic.id
+        return [
+            assignment
+            for assignment in assignments
+            if assignment.characteristic_id == characteristic_id
+        ]

--- a/src/qcc/reports/tagger_performance.py
+++ b/src/qcc/reports/tagger_performance.py
@@ -186,6 +186,15 @@ class TaggerPerformanceReport:
                         relevant_assignments, characteristic
                     )
 
+            per_tagger_metrics = metrics.per_tagger_metrics(
+                relevant_assignments, characteristic, methods
+            )
+            if per_tagger_metrics:
+                char_entry["per_tagger"] = [
+                    {"tagger_id": tagger_id, **per_tagger_metrics[tagger_id]}
+                    for tagger_id in sorted(per_tagger_metrics)
+                ]
+
             per_characteristic.append(char_entry)
 
         return {

--- a/tests/metrics/test_agreement_strategy.py
+++ b/tests/metrics/test_agreement_strategy.py
@@ -1,33 +1,92 @@
-from __future__ import annotations
+from datetime import datetime, timedelta
+
 import pytest
 
-# Note: We import the concrete class from the strategies folder
-from qcc.metrics.agreement_strategy import LatestLabelPercentAgreement
+from qcc.domain.characteristic import Characteristic
+from qcc.domain.enums import TagValue
+from qcc.domain.tagassignment import TagAssignment
 from qcc.domain.tagger import Tagger
+from qcc.metrics.agreement_strategy import LatestLabelPercentAgreement
 
-def make_empty_tagger() -> Tagger:
-    return Tagger(id="t0", meta=None, tagassignments=[])
 
-def test_latest_label_percent_agreement_signature():
-    """
-    Smoke test: Ensures the LatestLabelPercentAgreement class and its
-    pairwise method exist and correctly raise NotImplementedError.
-    """
-    strategy = LatestLabelPercentAgreement()
-    with pytest.raises(NotImplementedError):
-        # We assert that calling the method raises the expected error
-        strategy.pairwise(make_empty_tagger())
-        
-@pytest.mark.xfail(reason="Logic for LatestLabelPercentAgreement not yet implemented")
-def test_latest_label_percent_agreement_logic_placeholder():
-    """Placeholder for future implementation tests when the logic is added."""
-    # This test will be skipped (expected to fail) until the logic is written.
-    assert False
+def _assignment(tagger_id: str, comment_id: str, minutes: int, value: TagValue) -> TagAssignment:
+    return TagAssignment(
+        tagger_id=tagger_id,
+        comment_id=comment_id,
+        characteristic_id="char",
+        value=value,
+        timestamp=datetime(2024, 1, 1) + timedelta(minutes=minutes),
+    )
 
-def test_speed_strategy_is_pure_by_contract():
-    strategy = LatestLabelPercentAgreement()
-    t = make_empty_tagger()
-    with pytest.raises(NotImplementedError):
-        strategy.pairwise(t)
-    with pytest.raises(NotImplementedError):
-        strategy.pairwise(t)
+
+class TestLatestLabelPercentAgreement:
+    def setup_method(self) -> None:
+        self.strategy = LatestLabelPercentAgreement()
+        self.char = Characteristic("char", "Test")
+
+    def test_pairwise_uses_latest_labels(self) -> None:
+        tagger_a = Tagger(
+            "a",
+            tagassignments=[
+                _assignment("a", "c1", 0, TagValue.YES),
+                _assignment("a", "c1", -10, TagValue.NO),
+                _assignment("a", "c2", 1, TagValue.NO),
+            ],
+        )
+        tagger_b = Tagger(
+            "b",
+            tagassignments=[
+                _assignment("b", "c1", 2, TagValue.YES),
+                _assignment("b", "c2", 3, TagValue.NO),
+            ],
+        )
+
+        score = self.strategy.pairwise(tagger_a, tagger_b, self.char)
+        assert score == pytest.approx(1.0)
+
+    def test_percent_agreement_multiple_taggers(self) -> None:
+        assignments = [
+            _assignment("a", "c1", 0, TagValue.YES),
+            _assignment("b", "c1", 1, TagValue.YES),
+            _assignment("c", "c1", 2, TagValue.NO),
+            _assignment("a", "c2", 3, TagValue.NO),
+            _assignment("b", "c2", 4, TagValue.NO),
+            _assignment("c", "c2", 5, TagValue.NO),
+        ]
+
+        score = self.strategy.percent_agreement(assignments, self.char)
+        # For comment c1: pairs (a,b) agree, (a,c) disagree, (b,c) disagree -> 1/3
+        # For comment c2: all agree -> 3 agreements
+        # Total pairs = 6, agreements = 4
+        assert score == pytest.approx(4 / 6)
+
+    def test_cohens_kappa_without_overlap(self) -> None:
+        assignments = [
+            _assignment("a", "c1", 0, TagValue.YES),
+            _assignment("b", "c2", 0, TagValue.YES),
+        ]
+
+        score = self.strategy.cohens_kappa(assignments, self.char)
+        assert score == 0.0
+
+    def test_agreement_matrix_is_symmetric(self) -> None:
+        assignments = [
+            _assignment("a", "c1", 0, TagValue.YES),
+            _assignment("b", "c1", 1, TagValue.YES),
+            _assignment("a", "c2", 2, TagValue.NO),
+            _assignment("b", "c2", 3, TagValue.NO),
+        ]
+
+        matrix = self.strategy.agreement_matrix(assignments, self.char)
+        assert matrix == {"a": {"a": 1.0, "b": 1.0}, "b": {"a": 1.0, "b": 1.0}}
+
+    def test_krippendorff_alpha_reuses_matrix(self) -> None:
+        assignments = [
+            _assignment("a", "c1", 0, TagValue.YES),
+            _assignment("b", "c1", 1, TagValue.YES),
+            _assignment("a", "c2", 2, TagValue.NO),
+            _assignment("b", "c2", 3, TagValue.NO),
+        ]
+
+        score = self.strategy.krippendorff_alpha(assignments, self.char)
+        assert score == 1.0

--- a/tests/metrics/test_agreement_strategy.py
+++ b/tests/metrics/test_agreement_strategy.py
@@ -80,6 +80,28 @@ class TestLatestLabelPercentAgreement:
         matrix = self.strategy.agreement_matrix(assignments, self.char)
         assert matrix == {"a": {"a": 1.0, "b": 1.0}, "b": {"a": 1.0, "b": 1.0}}
 
+    def test_per_tagger_metrics_average_pairwise_scores(self) -> None:
+        assignments = [
+            _assignment("a", "c1", 0, TagValue.YES),
+            _assignment("b", "c1", 1, TagValue.YES),
+            _assignment("c", "c1", 2, TagValue.NO),
+            _assignment("a", "c2", 3, TagValue.NO),
+            _assignment("b", "c2", 4, TagValue.NO),
+            _assignment("c", "c2", 5, TagValue.NO),
+        ]
+
+        per_tagger = self.strategy.per_tagger_metrics(
+            assignments,
+            self.char,
+            ("percent_agreement", "cohens_kappa"),
+        )
+
+        assert per_tagger == {
+            "a": {"percent_agreement": pytest.approx(0.75), "cohens_kappa": pytest.approx(0.5)},
+            "b": {"percent_agreement": pytest.approx(0.75), "cohens_kappa": pytest.approx(0.5)},
+            "c": {"percent_agreement": pytest.approx(0.5), "cohens_kappa": pytest.approx(0.0)},
+        }
+
     def test_krippendorff_alpha_reuses_matrix(self) -> None:
         assignments = [
             _assignment("a", "c1", 0, TagValue.YES),

--- a/tests/test_agreement_signatures.py
+++ b/tests/test_agreement_signatures.py
@@ -1,73 +1,91 @@
-"""Test agreement metrics method signatures."""
+"""Integration tests for the agreement metrics façade."""
 
-import pytest
+from datetime import datetime, timedelta
 
 from qcc.domain.characteristic import Characteristic
+from qcc.domain.enums import TagValue
 from qcc.domain.tagassignment import TagAssignment
 from qcc.domain.tagger import Tagger
 from qcc.metrics.agreement import AgreementMetrics
+from qcc.metrics.agreement_strategy import LatestLabelPercentAgreement
+
+
+def _make_assignment(
+    tagger_id: str,
+    comment_id: str,
+    characteristic_id: str,
+    value: TagValue,
+    minutes: int,
+) -> TagAssignment:
+    return TagAssignment(
+        tagger_id=tagger_id,
+        comment_id=comment_id,
+        characteristic_id=characteristic_id,
+        value=value,
+        timestamp=datetime(2024, 1, 1, 0, 0, 0) + timedelta(minutes=minutes),
+    )
 
 
 class TestAgreementMetrics:
-    """Test AgreementMetrics class signatures."""
-    
-    def test_agreement_metrics_creation(self):
-        """Test that AgreementMetrics can be instantiated."""
-        metrics = AgreementMetrics()
-        assert isinstance(metrics, AgreementMetrics)
-    
-    def test_percent_agreement_signature(self):
-        """Test percent_agreement method signature."""
-        metrics = AgreementMetrics()
-        char = Characteristic("char1", "Test")
-        assignments = []
-        
-        with pytest.raises(NotImplementedError):
-            metrics.percent_agreement(assignments, char)
-    
-    def test_cohens_kappa_signature(self):
-        """Test cohens_kappa method signature."""
-        metrics = AgreementMetrics()
-        char = Characteristic("char1", "Test")
-        assignments = []
-        
-        with pytest.raises(NotImplementedError):
-            metrics.cohens_kappa(assignments, char)
-    
-    def test_krippendorffs_alpha_signature(self):
-        """Test krippendorffs_alpha method signature."""
-        metrics = AgreementMetrics()
-        char = Characteristic("char1", "Test")
-        assignments = []
-        
-        with pytest.raises(NotImplementedError):
-            metrics.krippendorffs_alpha(assignments, char)
-    
-    def test_pairwise_agreement_signature(self):
-        """Test pairwise_agreement method signature."""
-        metrics = AgreementMetrics()
-        tagger1 = Tagger("tagger1")
-        tagger2 = Tagger("tagger2")
-        char = Characteristic("char1", "Test")
-        
-        with pytest.raises(NotImplementedError):
-            metrics.pairwise_agreement(tagger1, tagger2, char)
-    
-    def test_agreement_matrix_signature(self):
-        """Test agreement_matrix method signature."""
-        metrics = AgreementMetrics()
-        char = Characteristic("char1", "Test")
-        assignments = []
-        
-        with pytest.raises(NotImplementedError):
-            metrics.agreement_matrix(assignments, char)
-    
-    def test_filter_assignments_signature(self):
-        """Test _filter_assignments_by_characteristic method signature."""
-        metrics = AgreementMetrics()
-        char = Characteristic("char1", "Test")
-        assignments = []
-        
-        with pytest.raises(NotImplementedError):
-            metrics._filter_assignments_by_characteristic(assignments, char)
+    """Validate the restored AgreementMetrics façade."""
+
+    def setup_method(self) -> None:
+        self.metrics = AgreementMetrics()
+        self.char = Characteristic("char1", "Test characteristic")
+        self.assignments = [
+            _make_assignment("tagger1", "comment1", self.char.id, TagValue.YES, 0),
+            _make_assignment("tagger2", "comment1", self.char.id, TagValue.YES, 1),
+            _make_assignment("tagger1", "comment2", self.char.id, TagValue.NO, 2),
+            _make_assignment("tagger2", "comment2", self.char.id, TagValue.NO, 3),
+            # Duplicate rating for tagger1 on comment1 that should be ignored (older)
+            _make_assignment("tagger1", "comment1", self.char.id, TagValue.NO, -10),
+            # Assignment for a different characteristic that must be filtered out
+            _make_assignment("tagger1", "comment3", "other", TagValue.YES, 4),
+        ]
+
+    def test_agreement_metrics_creation(self) -> None:
+        """AgreementMetrics can be instantiated and exposes helpers."""
+
+        assert isinstance(self.metrics, AgreementMetrics)
+        assert isinstance(self.metrics.strategy, LatestLabelPercentAgreement)
+
+    def test_percent_agreement(self) -> None:
+        """Percent agreement collapses latest ratings and matches perfectly."""
+
+        score = self.metrics.percent_agreement(self.assignments, self.char)
+        assert score == 1.0
+
+    def test_cohens_kappa(self) -> None:
+        """Cohen's kappa is 1.0 for perfect agreement."""
+
+        score = self.metrics.cohens_kappa(self.assignments, self.char)
+        assert score == 1.0
+
+    def test_krippendorffs_alpha(self) -> None:
+        """Krippendorff's alpha reports perfect agreement."""
+
+        score = self.metrics.krippendorffs_alpha(self.assignments, self.char)
+        assert score == 1.0
+
+    def test_pairwise_agreement(self) -> None:
+        """Pairwise agreement delegates to the strategy implementation."""
+
+        tagger1 = Tagger("tagger1", tagassignments=list(self.assignments))
+        tagger2 = Tagger("tagger2", tagassignments=list(self.assignments))
+
+        score = self.metrics.pairwise_agreement(tagger1, tagger2, self.char)
+        assert score == 1.0
+
+    def test_agreement_matrix(self) -> None:
+        """Agreement matrix yields a symmetric map keyed by tagger id."""
+
+        matrix = self.metrics.agreement_matrix(self.assignments, self.char)
+        assert matrix == {"tagger1": {"tagger1": 1.0, "tagger2": 1.0}, "tagger2": {"tagger1": 1.0, "tagger2": 1.0}}
+
+    def test_filter_assignments(self) -> None:
+        """Filtering retains only assignments for the requested characteristic."""
+
+        filtered = self.metrics._filter_assignments_by_characteristic(self.assignments, self.char)
+        assert all(assignment.characteristic_id == self.char.id for assignment in filtered)
+        assert len(filtered) == 5
 

--- a/tests/test_agreement_signatures.py
+++ b/tests/test_agreement_signatures.py
@@ -82,6 +82,20 @@ class TestAgreementMetrics:
         matrix = self.metrics.agreement_matrix(self.assignments, self.char)
         assert matrix == {"tagger1": {"tagger1": 1.0, "tagger2": 1.0}, "tagger2": {"tagger1": 1.0, "tagger2": 1.0}}
 
+    def test_per_tagger_metrics(self) -> None:
+        """Per-tagger metrics mirror the requested agreement methods."""
+
+        per_tagger = self.metrics.per_tagger_metrics(
+            self.assignments,
+            self.char,
+            ("percent_agreement", "cohens_kappa"),
+        )
+
+        assert per_tagger == {
+            "tagger1": {"percent_agreement": 1.0, "cohens_kappa": 1.0},
+            "tagger2": {"percent_agreement": 1.0, "cohens_kappa": 1.0},
+        }
+
     def test_filter_assignments(self) -> None:
         """Filtering retains only assignments for the requested characteristic."""
 

--- a/tests/test_db_adapter.py
+++ b/tests/test_db_adapter.py
@@ -485,3 +485,8 @@ def test_tagger_performance_report_includes_agreement_summary():
     assert char_entry["percent_agreement"] == pytest.approx(1.0)
     assert char_entry["cohens_kappa"] == pytest.approx(1.0)
     assert char_entry["krippendorffs_alpha"] == 1.0
+    per_tagger = {entry["tagger_id"]: entry for entry in char_entry["per_tagger"]}
+    assert per_tagger["1"]["percent_agreement"] == pytest.approx(1.0)
+    assert per_tagger["1"]["cohens_kappa"] == pytest.approx(1.0)
+    assert per_tagger["2"]["percent_agreement"] == pytest.approx(1.0)
+    assert per_tagger["2"]["cohens_kappa"] == pytest.approx(1.0)


### PR DESCRIPTION
## Summary
- delegate the agreement façade to LatestLabelPercentAgreement and expand the strategy with percent, kappa, matrix, and alpha helpers
- expose agreement results in the tagger performance report and cover the behavior with updated integration tests

## Testing
- pytest tests/test_agreement_signatures.py tests/metrics/test_agreement_strategy.py tests/test_db_adapter.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69124cf496308333827eb4cead2c94f5)