### PR TITLE
Add agreement metrics to summary report

### DIFF
--- a/src/qcc/cli/main.py
+++ b/src/qcc/cli/main.py
@@ -294,7 +294,11 @@ def run_analysis(
     characteristics = list(domain_objects.get("characteristics", []) or [])
 
     report = TaggerPerformanceReport(assignments)
-    summary = report.generate_summary_report(taggers, characteristics)
+    summary = report.generate_summary_report(
+        taggers,
+        characteristics,
+        include_agreement=True,
+    )
 
     report.export_to_csv(summary, output_dir / "summary.csv")
 


### PR DESCRIPTION
## Summary
- enable agreement calculations when running the CLI report generation
- include averaged per-user agreement metrics in the exported CSV output

## Testing
- PYTHONPATH=src pytest *(fails: missing optional modules referenced by existing tests)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914f8a7ba5c83338f16ff28ec660158)