### PR TITLE
Use assignment questionnaires to set assignment ids

### DIFF
--- a/docs/ASSIGNMENT_FLOW.md
+++ b/docs/ASSIGNMENT_FLOW.md
@@ -10,16 +10,20 @@ and how they are attached to taggers for reporting.
    supporting tables (`answers`, `assignment_questionnaires`,
    `tag_prompt_deployments`, `tag_prompts`, and `questions`) so assignment-level
    metadata can be enriched.
-3. **Parse each row** – `_row_to_assignment` extracts the required identifiers
-   (`tagger_id`, `comment_id`, `characteristic_id`) plus the tag value,
-   timestamp, and any provided prompt or team IDs, returning a `TagAssignment`
-   instance.
-4. **Override assignment IDs from authoritative tables** – When an
-   `assignment_questionnaires` row matches the assignment's `tagger_id`, its
-   `assignment_id` becomes the assignment identifier. If no questionnaire row
-   exists, a matching `tag_prompt_deployments` row (keyed by the
-   `characteristic_id`) contributes its `assignment_id`/`question_id` value. In
-   both cases, the authoritative ID replaces any value from the assignment row.
+3. **Parse each row** – `_parse_assignment_fields` extracts the required
+   identifiers (`comment_id`, `characteristic_id`), the tag value, timestamp,
+   any provided prompt or team IDs, and a `tagger_id` when present. Final
+   `TagAssignment` objects are instantiated after enrichment so missing tagger
+   IDs can be filled.
+4. **Override assignment IDs and fill missing taggers from authoritative tables** –
+   When an `assignment_questionnaires` row matches the assignment's
+   `tagger_id`, its `assignment_id` becomes the assignment identifier. If no
+   questionnaire row exists, a matching `tag_prompt_deployments` row (keyed by
+   the `characteristic_id`) contributes its `assignment_id`/`question_id`
+   value; the authoritative ID replaces any value from the assignment row. If
+   an assignment ID is available but the row omitted a `tagger_id`, the
+   adapter back-fills the tagger using the `assignment_questionnaires` mapping
+   keyed by `assignment_id` before creating the `TagAssignment`.
 5. **Collect metadata** – As assignments are appended, the adapter groups them by
    comment and tagger, and records comment/characteristic/tagger metadata to
    support later object construction.

--- a/docs/ASSIGNMENT_FLOW.md
+++ b/docs/ASSIGNMENT_FLOW.md
@@ -23,7 +23,10 @@ and how they are attached to taggers for reporting.
    value; the authoritative ID replaces any value from the assignment row. If
    an assignment ID is available but the row omitted a `tagger_id`, the
    adapter back-fills the tagger using the `assignment_questionnaires` mapping
-   keyed by `assignment_id` before creating the `TagAssignment`.
+   keyed by `assignment_id` before creating the `TagAssignment`. Rows missing
+   both a tagger ID and a corresponding `assignment_questionnaires` entry
+   cannot be ingested and will raise a `KeyError` so the missing ownership can
+   be corrected upstream.
 5. **Collect metadata** – As assignments are appended, the adapter groups them by
    comment and tagger, and records comment/characteristic/tagger metadata to
    support later object construction.

--- a/docs/ASSIGNMENT_FLOW.md
+++ b/docs/ASSIGNMENT_FLOW.md
@@ -1,0 +1,37 @@
+# Assignment ingestion and tagger attachment flow
+
+This note outlines how assignment rows from the database become domain objects
+and how they are attached to taggers for reporting.
+
+## Building assignments from database tables
+1. **Import rows** – The database adapter (`DBAdapter`) loads the configured
+   tables and passes the assignment table rows into `_build_assignments`.
+2. **Normalize lookups** – Within `_build_assignments`, the adapter indexes
+   supporting tables (`answers`, `assignment_questionnaires`,
+   `tag_prompt_deployments`, `tag_prompts`, and `questions`) so assignment-level
+   metadata can be enriched.
+3. **Parse each row** – `_row_to_assignment` extracts the required identifiers
+   (`tagger_id`, `comment_id`, `characteristic_id`) plus the tag value,
+   timestamp, and any provided prompt or team IDs, returning a `TagAssignment`
+   instance.
+4. **Override assignment IDs from authoritative tables** – When an
+   `assignment_questionnaires` row matches the assignment's `tagger_id`, its
+   `assignment_id` becomes the assignment identifier. If no questionnaire row
+   exists, a matching `tag_prompt_deployments` row (keyed by the
+   `characteristic_id`) contributes its `assignment_id`/`question_id` value. In
+   both cases, the authoritative ID replaces any value from the assignment row.
+5. **Collect metadata** – As assignments are appended, the adapter groups them by
+   comment and tagger, and records comment/characteristic/tagger metadata to
+   support later object construction.
+
+## Attaching assignments to taggers
+1. **Build taggers** – After assignments are built, `_build_taggers` walks the
+   grouped `assignments_by_tagger` map to instantiate each `Tagger` with its
+   corresponding list of `TagAssignment` objects.
+2. **Preserve tagger metadata** – Any tagger-level fields captured during
+   `_build_assignments` (for example, `team_id`) are forwarded as the `meta`
+   payload when each `Tagger` is created.
+
+The resulting taggers carry all timestamped assignments (with deployment-backed
+assignment IDs) that downstream reports consume for speed, pattern detection,
+and agreement calculations.

--- a/docs/REPORTS.md
+++ b/docs/REPORTS.md
@@ -111,6 +111,34 @@ detected in 12-assignment windows using the same 3- and 4-token repeat logic as
 CSV exports include one row per assignment per perspective with a semicolon-
 delimited `patterns` column (empty when no patterns were detected).
 
+### How patterns are detected and attached
+
+- **Input preparation:** Each tagger contributes only timestamped YES/NO
+  assignments. They are sorted chronologically and converted into token strings
+  for scanning.
+- **Window scan:** Non-overlapping 12-assignment windows are inspected. A window
+  is a hit only when its tokens are a perfect repetition of the first four
+  tokens (`abcdabcdabcd`) or first three tokens (`abcabcabcabc`). Windows
+  matching four-token repeats are masked before three-token matching to avoid
+  double-counting.
+- **Annotation:** When a window hits, every assignment in that window is
+  annotated with the literal repeated pattern (for example, `YYYY`, `NNNN`, or
+  `YYNN`). Assignments can accrue multiple pattern labels if they appear in more
+  than one matching window across perspectives.
+
+### CSV column reference
+
+- `user_id`, `assignment_id`, `comment_id`, `characteristic_id`, `prompt_id`,
+  `team_id` – identifiers copied directly from the enriched `TagAssignment`.
+- `timestamp` – the assignment's timestamp as ingested.
+- `perspective` – either `horizontal` (full tagger sequence) or `vertical`
+  (per characteristic, then merged per tagger).
+- `patterns` – semicolon-delimited list of patterns that include the assignment
+  for that perspective; empty when no pattern was detected for that row.
+
+Use the CSV export to trace any flagged pattern back to the exact assignment and
+context that produced it.
+
 ## Characteristic reliability report
 
 `CharacteristicReliabilityReport` is scaffolded but unimplemented. The

--- a/docs/REPORTS.md
+++ b/docs/REPORTS.md
@@ -11,6 +11,9 @@ written as timestamped files (e.g., `tagging-report-20240620-153045.csv`).
 pattern detection, and agreement (optional). The report accepts the full set of
 `Tagger` instances and the `TagAssignment` list they carry.
 
+For per-assignment visibility into pattern detection, see
+`PatternDetectionReport` below.
+
 ### Speed metrics
 
 Speed is calculated by the `LogTrimTaggingSpeed` strategy. For each tagger the
@@ -89,6 +92,24 @@ columnar CSV. Column prefixes indicate the source of each metric:
 Each row represents one tagger (`user_id`). Columns are added only when the
 corresponding metric exists in the summary payload, so the CSV remains compact
 for partial reports.
+
+## Assignment pattern detection report
+
+`PatternDetectionReport` produces assignment-level outputs for pattern detection
+so you can trace the signals back to individual tags. It reuses the horizontal
+and vertical perspectives:
+
+* **horizontal** – Chronological across all assignments for a tagger.
+* **vertical** – Per characteristic, then merged per tagger.
+
+The report returns every timestamped YES/NO assignment with metadata
+(`assignment_id`, `comment_id`, `characteristic_id`, `prompt_id`, `team_id`,
+`timestamp`). Each assignment lists the pattern(s) that include it. Patterns are
+detected in 12-assignment windows using the same 3- and 4-token repeat logic as
+`TaggerPerformanceReport`.
+
+CSV exports include one row per assignment per perspective with a semicolon-
+delimited `patterns` column (empty when no patterns were detected).
 
 ## Characteristic reliability report
 

--- a/src/qcc/data_ingestion/mysql_importer.py
+++ b/src/qcc/data_ingestion/mysql_importer.py
@@ -14,6 +14,7 @@ DEFAULT_TAG_PROMPT_TABLES: Sequence[str] = (
     "tag_prompt_deployments",
     "tag_prompts",
     "questions",
+    "assignment_questionnaires",
 )
 
 

--- a/src/qcc/io/csv_adapter.py
+++ b/src/qcc/io/csv_adapter.py
@@ -252,6 +252,18 @@ class CSVAdapter:
         value_raw = row.get("value")
         timestamp_raw = row.get("tagged_at")
 
+        assignment_id = row.get("assignment_id")
+        if assignment_id is not None:
+            assignment_id = str(assignment_id).strip() or None
+
+        prompt_id = row.get("prompt_id") or row.get("prompt")
+        if prompt_id is not None:
+            prompt_id = str(prompt_id).strip() or None
+
+        team_id = row.get("team_id")
+        if team_id is not None:
+            team_id = str(team_id).strip() or None
+
         if not tagger_id or not comment_id or not characteristic_id:
             raise ValueError(f"Missing required identifiers in row: {row!r}")
 
@@ -267,4 +279,7 @@ class CSVAdapter:
             characteristic_id=characteristic_id,
             value=tag_value,
             timestamp=timestamp,
+            assignment_id=assignment_id,
+            prompt_id=prompt_id,
+            team_id=team_id,
         )

--- a/src/qcc/reports/pattern_detection_report.py
+++ b/src/qcc/reports/pattern_detection_report.py
@@ -1,0 +1,292 @@
+"""Per-assignment pattern detection reporting."""
+
+from __future__ import annotations
+
+import csv
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence
+
+from qcc.domain.characteristic import Characteristic
+from qcc.domain.enums import TagValue
+from qcc.domain.tagassignment import TagAssignment
+from qcc.domain.tagger import Tagger
+from qcc.metrics.pattern_strategy import (
+    HorizontalPatternDetection,
+    VerticalPatternDetection,
+)
+from qcc.metrics.interfaces import PatternSignalsStrategy
+
+
+class PatternDetectionReport:
+    """Generate per-assignment pattern detection results."""
+
+    def __init__(self, assignments: Sequence[TagAssignment]) -> None:
+        self.assignments: List[TagAssignment] = list(assignments or [])
+
+    def generate_assignment_report(
+        self,
+        taggers: Sequence[Tagger],
+        characteristics: Sequence[Characteristic],
+    ) -> Dict[str, object]:
+        """Return pattern detection results for every assignment a user tagged."""
+
+        horizontal_strategy = HorizontalPatternDetection()
+        vertical_strategy = VerticalPatternDetection()
+
+        horizontal_assignments = self._build_horizontal_results(
+            taggers, horizontal_strategy
+        )
+        vertical_assignments = self._build_vertical_results(
+            taggers, characteristics, vertical_strategy
+        )
+
+        return {
+            "strategy": "PatternDetectionReport",
+            "horizontal": {
+                "strategy": horizontal_strategy.__class__.__name__,
+                "assignments": horizontal_assignments,
+            },
+            "vertical": {
+                "strategy": vertical_strategy.__class__.__name__,
+                "per_characteristic": vertical_assignments,
+            },
+        }
+
+    def export_to_csv(self, report_data: Mapping[str, object], output_path: Path) -> None:
+        """Export the per-assignment pattern results to CSV."""
+
+        csv_path = Path(output_path)
+        rows = self._build_csv_rows(report_data)
+        fieldnames = [
+            "user_id",
+            "assignment_id",
+            "comment_id",
+            "characteristic_id",
+            "prompt_id",
+            "team_id",
+            "timestamp",
+            "perspective",
+            "patterns",
+        ]
+
+        with csv_path.open("w", newline="", encoding="utf-8") as csv_file:
+            writer = csv.DictWriter(csv_file, fieldnames=fieldnames)
+            writer.writeheader()
+            for row in rows:
+                writer.writerow(row)
+
+    def _build_horizontal_results(
+        self, taggers: Sequence[Tagger], strategy: PatternSignalsStrategy
+    ) -> List[Dict[str, object]]:
+        per_assignment: List[Dict[str, object]] = []
+
+        for tagger in taggers:
+            assignments = self._eligible_assignments(tagger.tagassignments or [])
+            windows = self._pattern_windows(assignments, strategy)
+            per_assignment.extend(self._assignment_entries(assignments, windows))
+
+        return per_assignment
+
+    def _build_vertical_results(
+        self,
+        taggers: Sequence[Tagger],
+        characteristics: Sequence[Characteristic],
+        strategy: PatternSignalsStrategy,
+    ) -> List[Dict[str, object]]:
+        per_characteristic: List[Dict[str, object]] = []
+
+        for characteristic in characteristics:
+            characteristic_id = getattr(characteristic, "id", None)
+            if characteristic_id is None:
+                continue
+
+            characteristic_entries: List[Dict[str, object]] = []
+            for tagger in taggers:
+                assignments = self._eligible_assignments(
+                    assignment
+                    for assignment in (tagger.tagassignments or [])
+                    if getattr(assignment, "characteristic_id", None) == characteristic_id
+                )
+                if not assignments:
+                    continue
+
+                windows = self._pattern_windows(assignments, strategy)
+                characteristic_entries.extend(
+                    self._assignment_entries(assignments, windows)
+                )
+
+            if characteristic_entries:
+                per_characteristic.append(
+                    {
+                        "characteristic_id": str(characteristic_id),
+                        "assignments": characteristic_entries,
+                    }
+                )
+
+        return per_characteristic
+
+    def _pattern_windows(
+        self,
+        assignments: Sequence[TagAssignment],
+        strategy: PatternSignalsStrategy,
+        substring_length: int = 12,
+    ) -> List[tuple[int, str]]:
+        if not assignments:
+            return []
+
+        assignment_sequence = list(strategy.build_sequence_str(assignments))
+        sub_start = 0
+        track_4: List[tuple[int, str]] = []
+
+        while sub_start < len(assignment_sequence) - (substring_length - 1):
+            cur_sub = "".join(
+                assignment_sequence[sub_start : sub_start + substring_length]
+            )
+
+            first_pattern = cur_sub[0:4]
+            expected = first_pattern * (substring_length // len(first_pattern))
+            if cur_sub == expected:
+                track_4.append((sub_start, first_pattern))
+                sub_start += substring_length
+            else:
+                sub_start += 1
+
+        for start_pos, _ in track_4:
+            assignment_sequence[start_pos : start_pos + substring_length] = "#"
+
+        sub_start = 0
+        track_3: List[tuple[int, str]] = []
+
+        while sub_start < len(assignment_sequence) - (substring_length - 1):
+            cur_sub = "".join(
+                assignment_sequence[sub_start : sub_start + substring_length]
+            )
+            if "#" in cur_sub:
+                sub_start += substring_length
+                continue
+
+            first_pattern = cur_sub[0:3]
+            expected = first_pattern * (substring_length // len(first_pattern))
+            if cur_sub == expected:
+                track_3.append((sub_start, first_pattern))
+                sub_start += substring_length
+            else:
+                sub_start += 1
+
+        return [*track_4, *track_3]
+
+    def _assignment_entries(
+        self, assignments: Sequence[TagAssignment], windows: Sequence[tuple[int, str]]
+    ) -> List[Dict[str, object]]:
+        entries: List[Dict[str, object]] = []
+
+        for assignment in assignments:
+            entries.append(
+                {
+                    "tagger_id": str(assignment.tagger_id),
+                    "assignment_id": getattr(assignment, "assignment_id", None),
+                    "comment_id": getattr(assignment, "comment_id", None),
+                    "characteristic_id": getattr(assignment, "characteristic_id", None),
+                    "prompt_id": getattr(assignment, "prompt_id", None),
+                    "team_id": getattr(assignment, "team_id", None),
+                    "timestamp": self._timestamp_str(getattr(assignment, "timestamp", None)),
+                    "patterns": [],
+                }
+            )
+
+        for start_pos, pattern in windows:
+            for offset in range(12):
+                idx = start_pos + offset
+                if idx >= len(entries):
+                    break
+                entries[idx]["patterns"].append(pattern)
+
+        for entry in entries:
+            patterns = entry.get("patterns", []) or []
+            if patterns:
+                unique_patterns = sorted({str(pattern) for pattern in patterns})
+                entry["patterns"] = unique_patterns
+            else:
+                entry["patterns"] = []
+
+        return entries
+
+    def _build_csv_rows(self, report_data: Mapping[str, object]) -> List[Dict[str, str]]:
+        rows: List[Dict[str, str]] = []
+
+        horizontal = report_data.get("horizontal") if isinstance(report_data, Mapping) else None
+        if isinstance(horizontal, Mapping):
+            assignments = horizontal.get("assignments", []) or []
+            rows.extend(self._rows_from_assignments(assignments, perspective="horizontal"))
+
+        vertical = report_data.get("vertical") if isinstance(report_data, Mapping) else None
+        if isinstance(vertical, Mapping):
+            per_characteristic = vertical.get("per_characteristic", []) or []
+            for characteristic_entry in per_characteristic:
+                if not isinstance(characteristic_entry, Mapping):
+                    continue
+                assignments = characteristic_entry.get("assignments", []) or []
+                rows.extend(
+                    self._rows_from_assignments(
+                        assignments,
+                        perspective="vertical",
+                        characteristic_id=str(
+                            characteristic_entry.get("characteristic_id", "")
+                        ),
+                    )
+                )
+
+        return rows
+
+    def _rows_from_assignments(
+        self,
+        assignments: Iterable[Mapping[str, object]],
+        *,
+        perspective: str,
+        characteristic_id: Optional[str] = None,
+    ) -> List[Dict[str, str]]:
+        rows: List[Dict[str, str]] = []
+        for assignment in assignments:
+            if not isinstance(assignment, Mapping):
+                continue
+            patterns = assignment.get("patterns", []) or []
+            pattern_str = ";".join(patterns) if patterns else ""
+            row: MutableMapping[str, str] = {
+                "user_id": str(assignment.get("tagger_id", "")),
+                "assignment_id": str(assignment.get("assignment_id", "") or ""),
+                "comment_id": str(assignment.get("comment_id", "") or ""),
+                "characteristic_id": str(
+                    characteristic_id
+                    if characteristic_id is not None
+                    else assignment.get("characteristic_id", "")
+                ),
+                "prompt_id": str(assignment.get("prompt_id", "") or ""),
+                "team_id": str(assignment.get("team_id", "") or ""),
+                "timestamp": str(assignment.get("timestamp", "") or ""),
+                "perspective": perspective,
+                "patterns": pattern_str,
+            }
+
+            rows.append(dict(row))
+
+        return rows
+
+    @staticmethod
+    def _eligible_assignments(
+        assignments: Iterable[TagAssignment],
+    ) -> List[TagAssignment]:
+        eligible: List[TagAssignment] = []
+        for assignment in assignments:
+            timestamp = getattr(assignment, "timestamp", None)
+            value = getattr(assignment, "value", None)
+            if timestamp is None or value not in (TagValue.YES, TagValue.NO):
+                continue
+            eligible.append(assignment)
+
+        return sorted(eligible, key=lambda assignment: assignment.timestamp)
+
+    @staticmethod
+    def _timestamp_str(timestamp: Optional[datetime]) -> str:
+        return timestamp.isoformat() if isinstance(timestamp, datetime) else ""
+

--- a/tests/test_assignment_id_ingestion.py
+++ b/tests/test_assignment_id_ingestion.py
@@ -1,0 +1,113 @@
+from unittest.mock import MagicMock
+
+from qcc.data_ingestion.mysql_config import MySQLConfig
+from qcc.io.csv_adapter import CSVAdapter
+from qcc.io.db_adapter import DBAdapter
+
+
+def test_csv_adapter_preserves_assignment_id(tmp_path):
+    csv_path = tmp_path / "assignments.csv"
+    csv_path.write_text(
+        """
+assignment_id,team_id,tagger_id,comment_id,prompt_id,characteristic,value,tagged_at,comment_text,prompt_text
+assign-1,team-1,worker-1,comment-1,prompt-1,char-1,YES,2024-01-01T00:00:00Z,hello,prompt
+""".strip()
+    )
+
+    adapter = CSVAdapter()
+    assignments = adapter.read_assignments(csv_path)
+
+    assert assignments[0].assignment_id == "assign-1"
+    assert assignments[0].prompt_id == "prompt-1"
+    assert assignments[0].team_id == "team-1"
+
+
+def test_db_adapter_preserves_assignment_id():
+    adapter = DBAdapter(MySQLConfig("host", "user", "password", "database"), importer=MagicMock(), tables=["assignments"])
+
+    assignment = adapter._row_to_assignment(
+        {
+            "tagger_id": "worker-1",
+            "comment_id": "comment-1",
+            "characteristic_id": "char-1",
+            "value": 1,
+            "tagged_at": "2024-01-01T00:00:00Z",
+            "assignment_id": "assign-2",
+            "prompt_id": "prompt-2",
+            "team_id": "team-2",
+        }
+    )
+
+    assert assignment.assignment_id == "assign-2"
+    assert assignment.prompt_id == "prompt-2"
+    assert assignment.team_id == "team-2"
+
+
+def test_db_adapter_uses_deployment_assignment_id():
+    importer = MagicMock()
+    adapter = DBAdapter(
+        MySQLConfig("host", "user", "password", "database"),
+        importer=importer,
+        tables=["assignments", "tag_prompt_deployments"],
+    )
+
+    assignments, _ = adapter._build_assignments(
+        [
+            {
+                "tagger_id": "worker-1",
+                "comment_id": "comment-1",
+                "characteristic_id": "deployment-1",
+                "value": 1,
+                "tagged_at": "2024-01-01T00:00:00Z",
+                "assignment_id": "assign-from-row",
+            }
+        ],
+        {
+            "tag_prompt_deployments": [
+                {
+                    "id": "deployment-1",
+                    "assignment_id": "assign-from-deployment",
+                }
+            ]
+        },
+    )
+
+    assert len(assignments) == 1
+    assert assignments[0].assignment_id == "assign-from-deployment"
+
+
+def test_db_adapter_prefers_assignment_questionnaires_over_deployment():
+    importer = MagicMock()
+    adapter = DBAdapter(
+        MySQLConfig("host", "user", "password", "database"),
+        importer=importer,
+        tables=["assignments", "assignment_questionnaires", "tag_prompt_deployments"],
+    )
+
+    assignments, _ = adapter._build_assignments(
+        [
+            {
+                "tagger_id": "worker-1",
+                "comment_id": "comment-1",
+                "characteristic_id": "deployment-1",
+                "value": 1,
+                "tagged_at": "2024-01-01T00:00:00Z",
+                "assignment_id": "assign-from-row",
+            }
+        ],
+        {
+            "assignment_questionnaires": [
+                {"assignment_id": "assign-from-questionnaire", "user_id": "worker-1"}
+            ],
+            "tag_prompt_deployments": [
+                {
+                    "id": "deployment-1",
+                    "assignment_id": "assign-from-deployment",
+                }
+            ],
+        },
+    )
+
+    assert len(assignments) == 1
+    assert assignments[0].assignment_id == "assign-from-questionnaire"
+

--- a/tests/test_pattern_detection_report.py
+++ b/tests/test_pattern_detection_report.py
@@ -1,0 +1,71 @@
+from datetime import datetime, timedelta
+import csv
+
+from qcc.domain.characteristic import Characteristic
+from qcc.domain.enums import TagValue
+from qcc.domain.tagassignment import TagAssignment
+from qcc.domain.tagger import Tagger
+from qcc.reports.pattern_detection_report import PatternDetectionReport
+
+
+def _build_uniform_yes_assignments(count: int = 12) -> list[TagAssignment]:
+    start = datetime(2024, 1, 1, 0, 0, 0)
+    assignments = []
+    for i in range(count):
+        assignments.append(
+            TagAssignment(
+                tagger_id="worker-1",
+                comment_id=f"comment-{i}",
+                characteristic_id="char-1",
+                value=TagValue.YES,
+                timestamp=start + timedelta(seconds=i),
+                assignment_id=f"assign-{i}",
+            )
+        )
+
+    return assignments
+
+
+def test_horizontal_assignments_capture_pattern_window():
+    assignments = _build_uniform_yes_assignments()
+    tagger = Tagger(id="worker-1", tagassignments=assignments)
+    report = PatternDetectionReport(assignments)
+
+    data = report.generate_assignment_report([tagger], [])
+    horizontal = data["horizontal"]["assignments"]
+
+    assert len(horizontal) == len(assignments)
+    assert all("YYYY" in entry["patterns"] for entry in horizontal)
+
+
+def test_vertical_assignments_filtered_by_characteristic():
+    assignments = _build_uniform_yes_assignments()
+    tagger = Tagger(id="worker-1", tagassignments=assignments)
+    characteristic = Characteristic(id="char-1", name="Characteristic One")
+    report = PatternDetectionReport(assignments)
+
+    data = report.generate_assignment_report([tagger], [characteristic])
+    vertical = data["vertical"]["per_characteristic"][0]
+
+    assert vertical["characteristic_id"] == "char-1"
+    assert len(vertical["assignments"]) == len(assignments)
+    assert all("YYYY" in entry["patterns"] for entry in vertical["assignments"])
+
+
+def test_csv_export_writes_all_assignment_rows(tmp_path):
+    assignments = _build_uniform_yes_assignments()
+    tagger = Tagger(id="worker-1", tagassignments=assignments)
+    characteristic = Characteristic(id="char-1", name="Characteristic One")
+    report = PatternDetectionReport(assignments)
+
+    data = report.generate_assignment_report([tagger], [characteristic])
+    csv_path = tmp_path / "patterns.csv"
+    report.export_to_csv(data, csv_path)
+
+    with csv_path.open(newline="", encoding="utf-8") as csv_file:
+        reader = list(csv.DictReader(csv_file))
+
+    # 12 horizontal rows + 12 vertical rows
+    assert len(reader) == 24
+    assert all(row["patterns"] == "YYYY" for row in reader)
+    assert set(row["perspective"] for row in reader) == {"horizontal", "vertical"}


### PR DESCRIPTION
## Summary
- load assignment_questionnaires records and map assignment_ids by user for ingestion
- prioritize questionnaire-provided assignment_ids before deployment overrides when building TagAssignments
- document the authoritative ID flow and add regression coverage

## Testing
- python -m pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ccf1e94f4833391c3653e74d52f6b)