### PR TITLE
Add pattern coverage percentage to assignment pattern report

### DIFF
--- a/docs/ASSIGNMENT_FLOW.md
+++ b/docs/ASSIGNMENT_FLOW.md
@@ -4,30 +4,31 @@ This note outlines how assignment rows from the database become domain objects
 and how they are attached to taggers for reporting.
 
 ## Building assignments from database tables
-1. **Import rows** – The database adapter (`DBAdapter`) loads the configured
-   tables and passes the assignment table rows into `_build_assignments`.
-2. **Normalize lookups** – Within `_build_assignments`, the adapter indexes
+1. **Import rows** – The database adapter (`DBAdapter`) reads the tables listed
+   in `input.mysql.tables`; the first entry is always treated as the assignments
+   table (for example, `answer_tags`). All rows from that table are passed into
+   `_build_assignments`.
+2. **Normalize lookups** – Within `_build_assignments`, the adapter pre-indexes
    supporting tables (`answers`, `assignment_questionnaires`,
-   `tag_prompt_deployments`, `tag_prompts`, and `questions`) so assignment-level
-   metadata can be enriched.
+   `tag_prompt_deployments`, `tag_prompts`, and `questions`) so enrichment data
+   is ready before any assignment row is parsed.
 3. **Parse each row** – `_parse_assignment_fields` extracts the required
    identifiers (`comment_id`, `characteristic_id`, and `tagger_id`), the tag
-   value, timestamp, and any provided prompt or team IDs. Final `TagAssignment`
-   objects are instantiated after enrichment.
-4. **Resolve assignment IDs through questionnaire linkage** – Each assignment's
-   `comment_id` aligns with an `answers` row to recover the `question_id` for
-   that answer. The adapter then looks up the `questions` row for that
-   `question_id` to obtain its `questionnaire_id`, which is finally matched
-   against `assignment_questionnaires` to retrieve the authoritative
-   `assignment_id`. That ID replaces any value from the assignment row. If no
-   questionnaire match exists, a `tag_prompt_deployments` row keyed by the
-   `characteristic_id` can contribute its `assignment_id`/`question_id` value;
-   if neither path yields an ID, the assignment keeps the row-level value.
-   Rows missing a `tagger_id` still raise a `KeyError` so ownership issues are
-   exposed early.
+   value, timestamp, and any provided prompt or team IDs. Rows without a
+   tagger/worker/user raise a `KeyError` immediately. Parsed fields are carried
+   forward to the enrichment step before a `TagAssignment` is created.
+4. **Resolve assignment IDs via questionnaire linkage** – For every parsed row,
+   the adapter follows the chain `comment_id → answers.question_id →
+   questions.questionnaire_id → assignment_questionnaires.assignment_id` to find
+   the authoritative assignment identifier. If that chain produces a value, it
+   overwrites any ID from the assignment row. When the questionnaire lookup is
+   empty, the adapter falls back to the `tag_prompt_deployments` row keyed by the
+   `characteristic_id`, then to any row-level ID, and finally marks the ID as
+   missing.
 5. **Collect metadata** – As assignments are appended, the adapter groups them by
-   comment and tagger, and records comment/characteristic/tagger metadata to
-   support later object construction.
+   comment and tagger, and records comment/characteristic/tagger metadata (plus
+   ID-resolution statistics and a sample wiring log) to support later object
+   construction.
 
 ## Attaching assignments to taggers
 1. **Build taggers** – After assignments are built, `_build_taggers` walks the

--- a/docs/ASSIGNMENT_FLOW.md
+++ b/docs/ASSIGNMENT_FLOW.md
@@ -1,0 +1,42 @@
+# Assignment ingestion and tagger attachment flow
+
+This note outlines how assignment rows from the database become domain objects
+and how they are attached to taggers for reporting.
+
+## Building assignments from database tables
+1. **Import rows** – The database adapter (`DBAdapter`) loads the configured
+   tables and passes the assignment table rows into `_build_assignments`.
+2. **Normalize lookups** – Within `_build_assignments`, the adapter indexes
+   supporting tables (`answers`, `assignment_questionnaires`,
+   `tag_prompt_deployments`, `tag_prompts`, and `questions`) so assignment-level
+   metadata can be enriched.
+3. **Parse each row** – `_parse_assignment_fields` extracts the required
+   identifiers (`comment_id`, `characteristic_id`, and `tagger_id`), the tag
+   value, timestamp, and any provided prompt or team IDs. Final `TagAssignment`
+   objects are instantiated after enrichment.
+4. **Resolve assignment IDs through questionnaire linkage** – Each assignment's
+   `comment_id` aligns with an `answers` row to recover the `question_id` for
+   that answer. The adapter then looks up the `questions` row for that
+   `question_id` to obtain its `questionnaire_id`, which is finally matched
+   against `assignment_questionnaires` to retrieve the authoritative
+   `assignment_id`. That ID replaces any value from the assignment row. If no
+   questionnaire match exists, a `tag_prompt_deployments` row keyed by the
+   `characteristic_id` can contribute its `assignment_id`/`question_id` value;
+   if neither path yields an ID, the assignment keeps the row-level value.
+   Rows missing a `tagger_id` still raise a `KeyError` so ownership issues are
+   exposed early.
+5. **Collect metadata** – As assignments are appended, the adapter groups them by
+   comment and tagger, and records comment/characteristic/tagger metadata to
+   support later object construction.
+
+## Attaching assignments to taggers
+1. **Build taggers** – After assignments are built, `_build_taggers` walks the
+   grouped `assignments_by_tagger` map to instantiate each `Tagger` with its
+   corresponding list of `TagAssignment` objects.
+2. **Preserve tagger metadata** – Any tagger-level fields captured during
+   `_build_assignments` (for example, `team_id`) are forwarded as the `meta`
+   payload when each `Tagger` is created.
+
+The resulting taggers carry all timestamped assignments (with deployment-backed
+assignment IDs) that downstream reports consume for speed, pattern detection,
+and agreement calculations.

--- a/docs/REPORTS.md
+++ b/docs/REPORTS.md
@@ -5,6 +5,16 @@ its metrics are calculated. Use it as a quick reference when interpreting
 `summary.json` output or CSV exports produced by the CLI. CSV exports are
 written as timestamped files (e.g., `tagging-report-20240620-153045.csv`).
 
+## Data inputs and object model
+
+Reports consume the domain objects built by the MySQL importer. Assignment rows
+from the first configured table (typically `answer_tags`) are enriched via
+`answers` → `questions` → `assignment_questionnaires` to recover the
+authoritative `assignment_id`, with `tag_prompt_deployments` supplying a
+secondary assignment ID when needed. Rows missing a tagger are rejected during
+parsing. The resulting `TagAssignment` objects (plus comments, taggers,
+characteristics, prompts, and questions) are what the report classes read.
+
 ## Tagger performance report
 
 `TaggerPerformanceReport` bundles three families of metrics: tagging speed,

--- a/docs/REPORTS.md
+++ b/docs/REPORTS.md
@@ -11,6 +11,9 @@ written as timestamped files (e.g., `tagging-report-20240620-153045.csv`).
 pattern detection, and agreement (optional). The report accepts the full set of
 `Tagger` instances and the `TagAssignment` list they carry.
 
+For per-assignment visibility into pattern detection, see
+`PatternDetectionReport` below.
+
 ### Speed metrics
 
 Speed is calculated by the `LogTrimTaggingSpeed` strategy. For each tagger the
@@ -89,6 +92,63 @@ columnar CSV. Column prefixes indicate the source of each metric:
 Each row represents one tagger (`user_id`). Columns are added only when the
 corresponding metric exists in the summary payload, so the CSV remains compact
 for partial reports.
+
+## Assignment pattern detection report
+
+`PatternDetectionReport` produces assignment-level outputs for pattern detection
+so you can trace the signals back to individual assignments. It reuses the
+horizontal and vertical perspectives, but pattern detection always runs within
+each tagger's individual assignment (all answer tags sharing an
+`assignment_id`). In addition to the detected patterns, each assignment row
+reports what percentage of its timestamped YES/NO tags belong to a detected
+pattern window.
+
+The report returns a single entry for every tagger/assignment pair with
+metadata (`assignment_id`, `comment_id`, `prompt_id`, `timestamp`) plus the
+pattern(s) found when scanning that assignment's answer tags. Patterns are
+detected in 12-assignment windows using the same 3- and 4-token repeat logic as
+`TaggerPerformanceReport`.
+
+CSV exports include one row per assignment per perspective with a semicolon-
+delimited `patterns` column (empty when no patterns were detected) and a
+boolean `pattern_detected` column for quick filtering. Only `user_id`,
+`assignment_id`, `comment_id`, `prompt_id`, `timestamp`, `perspective`, and the
+pattern columns are emitted.
+
+### How patterns are detected and attached
+
+- **Input preparation:** For each tagger, assignments are grouped by
+  `assignment_id`. Within each group only timestamped YES/NO tags are kept,
+  sorted chronologically, and converted into token strings for scanning.
+- **Window scan:** Non-overlapping 12-assignment windows within the assignment
+  are inspected. A window is a hit only when its tokens are a perfect
+  repetition of the first four tokens (`abcdabcdabcd`) or first three tokens
+  (`abcabcabcabc`). Windows matching four-token repeats are masked before three-
+  token matching to avoid double-counting.
+- **Annotation:** When a window hits, the assignment is marked with the literal
+  repeated pattern (for example, `YYYY`, `NNNN`, or `YYNN`), and
+  `pattern_detected` is set to `true` for that tagger/assignment pair. An
+  assignment can accrue multiple pattern labels if multiple windows match.
+
+### CSV column reference
+
+- `user_id`, `assignment_id`, `comment_id`, `prompt_id` – identifiers copied
+  directly from the enriched `TagAssignment`.
+- `timestamp` – the earliest timestamp among the assignment's eligible tags.
+- `perspective` – either `horizontal` (full tagger sequence grouped by
+  assignment) or `vertical` (per characteristic, then merged per tagger, still
+  grouped by assignment).
+- `patterns` – semicolon-delimited list of patterns that hit within the
+  assignment for that perspective; empty when no pattern was detected for that
+  row.
+- `pattern_detected` – `true` when any pattern was found for that assignment and
+  perspective, else `false`.
+- `pattern_coverage` – percentage (0–100, rounded to two decimal places) of the
+  assignment's eligible tags that fell inside one or more detected pattern
+  windows.
+
+Use the CSV export to trace any flagged pattern back to the exact assignment and
+context that produced it.
 
 ## Characteristic reliability report
 

--- a/src/qcc/data_ingestion/mysql_importer.py
+++ b/src/qcc/data_ingestion/mysql_importer.py
@@ -14,6 +14,7 @@ DEFAULT_TAG_PROMPT_TABLES: Sequence[str] = (
     "tag_prompt_deployments",
     "tag_prompts",
     "questions",
+    "assignment_questionnaires",
 )
 
 

--- a/src/qcc/io/csv_adapter.py
+++ b/src/qcc/io/csv_adapter.py
@@ -252,6 +252,18 @@ class CSVAdapter:
         value_raw = row.get("value")
         timestamp_raw = row.get("tagged_at")
 
+        assignment_id = row.get("assignment_id")
+        if assignment_id is not None:
+            assignment_id = str(assignment_id).strip() or None
+
+        prompt_id = row.get("prompt_id") or row.get("prompt")
+        if prompt_id is not None:
+            prompt_id = str(prompt_id).strip() or None
+
+        team_id = row.get("team_id")
+        if team_id is not None:
+            team_id = str(team_id).strip() or None
+
         if not tagger_id or not comment_id or not characteristic_id:
             raise ValueError(f"Missing required identifiers in row: {row!r}")
 
@@ -267,4 +279,7 @@ class CSVAdapter:
             characteristic_id=characteristic_id,
             value=tag_value,
             timestamp=timestamp,
+            assignment_id=assignment_id,
+            prompt_id=prompt_id,
+            team_id=team_id,
         )

--- a/src/qcc/reports/pattern_detection_report.py
+++ b/src/qcc/reports/pattern_detection_report.py
@@ -1,0 +1,326 @@
+"""Per-assignment pattern detection reporting."""
+
+from __future__ import annotations
+
+import csv
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence
+
+from qcc.domain.characteristic import Characteristic
+from qcc.domain.enums import TagValue
+from qcc.domain.tagassignment import TagAssignment
+from qcc.domain.tagger import Tagger
+from qcc.metrics.pattern_strategy import (
+    HorizontalPatternDetection,
+    VerticalPatternDetection,
+)
+from qcc.metrics.interfaces import PatternSignalsStrategy
+
+
+class PatternDetectionReport:
+    """Generate per-assignment pattern detection results."""
+
+    def __init__(self, assignments: Sequence[TagAssignment]) -> None:
+        self.assignments: List[TagAssignment] = list(assignments or [])
+
+    def generate_assignment_report(
+        self,
+        taggers: Sequence[Tagger],
+        characteristics: Sequence[Characteristic],
+    ) -> Dict[str, object]:
+        """Return pattern detection results for every assignment a user tagged."""
+
+        horizontal_strategy = HorizontalPatternDetection()
+        vertical_strategy = VerticalPatternDetection()
+
+        horizontal_assignments = self._build_horizontal_results(
+            taggers, horizontal_strategy
+        )
+        vertical_assignments = self._build_vertical_results(
+            taggers, characteristics, vertical_strategy
+        )
+
+        return {
+            "strategy": "PatternDetectionReport",
+            "horizontal": {
+                "strategy": horizontal_strategy.__class__.__name__,
+                "assignments": horizontal_assignments,
+            },
+            "vertical": {
+                "strategy": vertical_strategy.__class__.__name__,
+                "per_characteristic": vertical_assignments,
+            },
+        }
+
+    def export_to_csv(self, report_data: Mapping[str, object], output_path: Path) -> None:
+        """Export the per-assignment pattern results to CSV."""
+
+        csv_path = Path(output_path)
+        rows = self._build_csv_rows(report_data)
+        fieldnames = [
+            "user_id",
+            "assignment_id",
+            "comment_id",
+            "prompt_id",
+            "timestamp",
+            "perspective",
+            "patterns",
+            "pattern_detected",
+            "pattern_coverage",
+        ]
+
+        with csv_path.open("w", newline="", encoding="utf-8") as csv_file:
+            writer = csv.DictWriter(csv_file, fieldnames=fieldnames)
+            writer.writeheader()
+            for row in rows:
+                writer.writerow(row)
+
+    def _build_horizontal_results(
+        self, taggers: Sequence[Tagger], strategy: PatternSignalsStrategy
+    ) -> List[Dict[str, object]]:
+        per_assignment: List[Dict[str, object]] = []
+
+        for tagger in taggers:
+            grouped = self._group_assignments_by_id(tagger.tagassignments or [])
+            for assignment_id, assignments in grouped.items():
+                eligible_assignments = self._eligible_assignments(assignments)
+                windows = self._pattern_windows(eligible_assignments, strategy)
+                per_assignment.extend(
+                    self._assignment_entries(
+                        eligible_assignments, windows, assignment_id=assignment_id
+                    )
+                )
+
+        return per_assignment
+
+    def _build_vertical_results(
+        self,
+        taggers: Sequence[Tagger],
+        characteristics: Sequence[Characteristic],
+        strategy: PatternSignalsStrategy,
+    ) -> List[Dict[str, object]]:
+        per_characteristic: List[Dict[str, object]] = []
+
+        for characteristic in characteristics:
+            characteristic_id = getattr(characteristic, "id", None)
+            if characteristic_id is None:
+                continue
+
+            characteristic_entries: List[Dict[str, object]] = []
+            for tagger in taggers:
+                assignments = [
+                    assignment
+                    for assignment in (tagger.tagassignments or [])
+                    if getattr(assignment, "characteristic_id", None) == characteristic_id
+                ]
+                grouped = self._group_assignments_by_id(assignments)
+                for assignment_id, characteristic_assignments in grouped.items():
+                    eligible_assignments = self._eligible_assignments(
+                        characteristic_assignments
+                    )
+                    if not eligible_assignments:
+                        continue
+
+                    windows = self._pattern_windows(eligible_assignments, strategy)
+                    characteristic_entries.extend(
+                        self._assignment_entries(
+                            eligible_assignments,
+                            windows,
+                            assignment_id=assignment_id,
+                        )
+                    )
+
+            if characteristic_entries:
+                per_characteristic.append(
+                    {
+                        "characteristic_id": str(characteristic_id),
+                        "assignments": characteristic_entries,
+                    }
+                )
+
+        return per_characteristic
+
+    def _pattern_windows(
+        self,
+        assignments: Sequence[TagAssignment],
+        strategy: PatternSignalsStrategy,
+        substring_length: int = 12,
+    ) -> List[tuple[int, str]]:
+        if not assignments:
+            return []
+
+        assignment_sequence = list(strategy.build_sequence_str(assignments))
+        sub_start = 0
+        track_4: List[tuple[int, str]] = []
+
+        while sub_start < len(assignment_sequence) - (substring_length - 1):
+            cur_sub = "".join(
+                assignment_sequence[sub_start : sub_start + substring_length]
+            )
+
+            first_pattern = cur_sub[0:4]
+            expected = first_pattern * (substring_length // len(first_pattern))
+            if cur_sub == expected:
+                track_4.append((sub_start, first_pattern))
+                sub_start += substring_length
+            else:
+                sub_start += 1
+
+        for start_pos, _ in track_4:
+            assignment_sequence[start_pos : start_pos + substring_length] = "#"
+
+        sub_start = 0
+        track_3: List[tuple[int, str]] = []
+
+        while sub_start < len(assignment_sequence) - (substring_length - 1):
+            cur_sub = "".join(
+                assignment_sequence[sub_start : sub_start + substring_length]
+            )
+            if "#" in cur_sub:
+                sub_start += substring_length
+                continue
+
+            first_pattern = cur_sub[0:3]
+            expected = first_pattern * (substring_length // len(first_pattern))
+            if cur_sub == expected:
+                track_3.append((sub_start, first_pattern))
+                sub_start += substring_length
+            else:
+                sub_start += 1
+
+        return [*track_4, *track_3]
+
+    def _assignment_entries(
+        self,
+        assignments: Sequence[TagAssignment],
+        windows: Sequence[tuple[int, str]],
+        *,
+        assignment_id: Optional[str],
+    ) -> List[Dict[str, object]]:
+        if not assignments:
+            return []
+
+        first = assignments[0]
+        timestamp = getattr(first, "timestamp", None)
+        patterns = sorted({pattern for _, pattern in windows})
+        coverage = self._pattern_coverage(assignments, windows)
+
+        return [
+            {
+                "tagger_id": str(first.tagger_id),
+                "assignment_id": assignment_id,
+                "comment_id": getattr(first, "comment_id", None),
+                "prompt_id": getattr(first, "prompt_id", None),
+                "timestamp": self._timestamp_str(timestamp),
+                "patterns": patterns,
+                "pattern_detected": bool(patterns),
+                "pattern_coverage": coverage,
+            }
+        ]
+
+    @staticmethod
+    def _group_assignments_by_id(
+        assignments: Iterable[TagAssignment],
+    ) -> Dict[str, List[TagAssignment]]:
+        grouped: Dict[str, List[TagAssignment]] = {}
+        for assignment in assignments:
+            assignment_id = getattr(assignment, "assignment_id", None)
+            if assignment_id is None:
+                continue
+
+            grouped.setdefault(str(assignment_id), []).append(assignment)
+
+        return grouped
+
+    def _build_csv_rows(self, report_data: Mapping[str, object]) -> List[Dict[str, str]]:
+        rows: List[Dict[str, str]] = []
+
+        horizontal = report_data.get("horizontal") if isinstance(report_data, Mapping) else None
+        if isinstance(horizontal, Mapping):
+            assignments = horizontal.get("assignments", []) or []
+            rows.extend(self._rows_from_assignments(assignments, perspective="horizontal"))
+
+        vertical = report_data.get("vertical") if isinstance(report_data, Mapping) else None
+        if isinstance(vertical, Mapping):
+            per_characteristic = vertical.get("per_characteristic", []) or []
+            for characteristic_entry in per_characteristic:
+                if not isinstance(characteristic_entry, Mapping):
+                    continue
+                assignments = characteristic_entry.get("assignments", []) or []
+                rows.extend(
+                    self._rows_from_assignments(
+                        assignments,
+                        perspective="vertical",
+                        characteristic_id=str(
+                            characteristic_entry.get("characteristic_id", "")
+                        ),
+                    )
+                )
+
+        return rows
+
+    def _rows_from_assignments(
+        self,
+        assignments: Iterable[Mapping[str, object]],
+        *,
+        perspective: str,
+        characteristic_id: Optional[str] = None,
+    ) -> List[Dict[str, str]]:
+        rows: List[Dict[str, str]] = []
+        for assignment in assignments:
+            if not isinstance(assignment, Mapping):
+                continue
+            patterns = assignment.get("patterns", []) or []
+            pattern_str = ";".join(patterns) if patterns else ""
+            row: MutableMapping[str, str] = {
+                "user_id": str(assignment.get("tagger_id", "")),
+                "assignment_id": str(assignment.get("assignment_id", "") or ""),
+                "comment_id": str(assignment.get("comment_id", "") or ""),
+                "prompt_id": str(assignment.get("prompt_id", "") or ""),
+                "timestamp": str(assignment.get("timestamp", "") or ""),
+                "perspective": perspective,
+                "patterns": pattern_str,
+                "pattern_detected": str(bool(patterns)).lower(),
+                "pattern_coverage": str(assignment.get("pattern_coverage", "") or ""),
+            }
+
+            rows.append(dict(row))
+
+        return rows
+
+    @staticmethod
+    def _eligible_assignments(
+        assignments: Iterable[TagAssignment],
+    ) -> List[TagAssignment]:
+        eligible: List[TagAssignment] = []
+        for assignment in assignments:
+            timestamp = getattr(assignment, "timestamp", None)
+            value = getattr(assignment, "value", None)
+            if timestamp is None or value not in (TagValue.YES, TagValue.NO):
+                continue
+            eligible.append(assignment)
+
+        return sorted(eligible, key=lambda assignment: assignment.timestamp)
+
+    @staticmethod
+    def _timestamp_str(timestamp: Optional[datetime]) -> str:
+        return timestamp.isoformat() if isinstance(timestamp, datetime) else ""
+
+    @staticmethod
+    def _pattern_coverage(
+        assignments: Sequence[TagAssignment],
+        windows: Sequence[tuple[int, str]],
+        substring_length: int = 12,
+    ) -> float:
+        assignment_count = len(assignments)
+        if assignment_count == 0 or not windows:
+            return 0.0
+
+        covered_positions = set()
+        for start, _ in windows:
+            covered_positions.update(range(start, start + substring_length))
+
+        coverage_ratio = len(covered_positions) / assignment_count
+        return round(coverage_ratio * 100, 2)
+

--- a/tests/test_assignment_id_ingestion.py
+++ b/tests/test_assignment_id_ingestion.py
@@ -1,0 +1,135 @@
+from unittest.mock import MagicMock
+
+from qcc.data_ingestion.mysql_config import MySQLConfig
+from qcc.io.csv_adapter import CSVAdapter
+from qcc.io.db_adapter import DBAdapter
+
+
+def test_csv_adapter_preserves_assignment_id(tmp_path):
+    csv_path = tmp_path / "assignments.csv"
+    csv_path.write_text(
+        """
+assignment_id,team_id,tagger_id,comment_id,prompt_id,characteristic,value,tagged_at,comment_text,prompt_text
+assign-1,team-1,worker-1,comment-1,prompt-1,char-1,YES,2024-01-01T00:00:00Z,hello,prompt
+""".strip()
+    )
+
+    adapter = CSVAdapter()
+    assignments = adapter.read_assignments(csv_path)
+
+    assert assignments[0].assignment_id == "assign-1"
+    assert assignments[0].prompt_id == "prompt-1"
+    assert assignments[0].team_id == "team-1"
+
+
+def test_db_adapter_preserves_assignment_id():
+    adapter = DBAdapter(MySQLConfig("host", "user", "password", "database"), importer=MagicMock(), tables=["assignments"])
+
+    assignment = adapter._row_to_assignment(
+        {
+            "tagger_id": "worker-1",
+            "comment_id": "comment-1",
+            "characteristic_id": "char-1",
+            "value": 1,
+            "tagged_at": "2024-01-01T00:00:00Z",
+            "assignment_id": "assign-2",
+            "prompt_id": "prompt-2",
+            "team_id": "team-2",
+        }
+    )
+
+    assert assignment.assignment_id == "assign-2"
+    assert assignment.prompt_id == "prompt-2"
+    assert assignment.team_id == "team-2"
+
+
+def test_db_adapter_resolves_assignment_via_questionnaire_chain():
+    importer = MagicMock()
+    adapter = DBAdapter(
+        MySQLConfig("host", "user", "password", "database"),
+        importer=importer,
+        tables=[
+            "assignments",
+            "answers",
+            "questions",
+            "assignment_questionnaires",
+            "tag_prompt_deployments",
+        ],
+    )
+
+    assignments, _ = adapter._build_assignments(
+        [
+            {
+                "tagger_id": "worker-1",
+                "comment_id": "comment-1",
+                "characteristic_id": "deployment-1",
+                "value": 1,
+                "tagged_at": "2024-01-01T00:00:00Z",
+                "assignment_id": "assign-from-row",
+            }
+        ],
+        {
+            "answers": [
+                {"id": "comment-1", "question_id": "question-1"},
+            ],
+            "questions": [
+                {"id": "question-1", "questionnaire_id": "questionnaire-1"}
+            ],
+            "assignment_questionnaires": [
+                {
+                    "questionnaire_id": "questionnaire-1",
+                    "assignment_id": "assign-from-questionnaire",
+                }
+            ],
+            "tag_prompt_deployments": [
+                {"id": "deployment-1", "assignment_id": "assign-from-deployment"}
+            ],
+        },
+    )
+
+    assert len(assignments) == 1
+    assert assignments[0].assignment_id == "assign-from-questionnaire"
+
+
+def test_db_adapter_uses_deployment_when_questionnaire_missing():
+    importer = MagicMock()
+    adapter = DBAdapter(
+        MySQLConfig("host", "user", "password", "database"),
+        importer=importer,
+        tables=[
+            "assignments",
+            "answers",
+            "questions",
+            "assignment_questionnaires",
+            "tag_prompt_deployments",
+        ],
+    )
+
+    assignments, _ = adapter._build_assignments(
+        [
+            {
+                "tagger_id": "worker-1",
+                "comment_id": "comment-1",
+                "characteristic_id": "deployment-1",
+                "value": 1,
+                "tagged_at": "2024-01-01T00:00:00Z",
+                "assignment_id": "assign-from-row",
+            }
+        ],
+        {
+            "answers": [
+                {"id": "comment-1", "question_id": "question-1"},
+            ],
+            "questions": [
+                {"id": "question-1"}
+            ],
+            "assignment_questionnaires": [],
+            "tag_prompt_deployments": [
+                {"id": "deployment-1", "assignment_id": "assign-from-deployment"}
+            ],
+        },
+    )
+
+    assert len(assignments) == 1
+    assert assignments[0].assignment_id == "assign-from-deployment"
+

--- a/tests/test_pattern_detection_report.py
+++ b/tests/test_pattern_detection_report.py
@@ -1,0 +1,99 @@
+from datetime import datetime, timedelta
+import csv
+
+from qcc.domain.characteristic import Characteristic
+from qcc.domain.enums import TagValue
+from qcc.domain.tagassignment import TagAssignment
+from qcc.domain.tagger import Tagger
+from qcc.reports.pattern_detection_report import PatternDetectionReport
+
+
+def _build_uniform_yes_assignments(count: int = 12, assignment_id: str = "assign-1") -> list[TagAssignment]:
+    start = datetime(2024, 1, 1, 0, 0, 0)
+    assignments = []
+    for i in range(count):
+        assignments.append(
+            TagAssignment(
+                tagger_id="worker-1",
+                comment_id=f"comment-{i}",
+                characteristic_id="char-1",
+                value=TagValue.YES,
+                timestamp=start + timedelta(seconds=i),
+                assignment_id=assignment_id,
+            )
+        )
+
+    return assignments
+
+
+def test_horizontal_assignments_capture_pattern_window():
+    assignments = _build_uniform_yes_assignments()
+    tagger = Tagger(id="worker-1", tagassignments=assignments)
+    report = PatternDetectionReport(assignments)
+
+    data = report.generate_assignment_report([tagger], [])
+    horizontal = data["horizontal"]["assignments"]
+
+    assert len(horizontal) == 1
+    assert horizontal[0]["patterns"] == ["YYYY"]
+    assert horizontal[0]["pattern_detected"] is True
+    assert horizontal[0]["assignment_id"] == "assign-1"
+    assert horizontal[0]["pattern_coverage"] == 100.0
+
+
+def test_vertical_assignments_filtered_by_characteristic():
+    assignments = _build_uniform_yes_assignments()
+    tagger = Tagger(id="worker-1", tagassignments=assignments)
+    characteristic = Characteristic(id="char-1", name="Characteristic One")
+    report = PatternDetectionReport(assignments)
+
+    data = report.generate_assignment_report([tagger], [characteristic])
+    vertical = data["vertical"]["per_characteristic"][0]
+
+    assert vertical["characteristic_id"] == "char-1"
+    assert len(vertical["assignments"]) == 1
+    assert vertical["assignments"][0]["patterns"] == ["YYYY"]
+    assert vertical["assignments"][0]["pattern_detected"] is True
+    assert vertical["assignments"][0]["pattern_coverage"] == 100.0
+
+
+def test_csv_export_writes_all_assignment_rows(tmp_path):
+    assignments = _build_uniform_yes_assignments()
+    tagger = Tagger(id="worker-1", tagassignments=assignments)
+    characteristic = Characteristic(id="char-1", name="Characteristic One")
+    report = PatternDetectionReport(assignments)
+
+    data = report.generate_assignment_report([tagger], [characteristic])
+    csv_path = tmp_path / "patterns.csv"
+    report.export_to_csv(data, csv_path)
+
+    with csv_path.open(newline="", encoding="utf-8") as csv_file:
+        reader = list(csv.DictReader(csv_file))
+
+    # 1 horizontal row + 1 vertical row
+    assert len(reader) == 2
+    assert all(row["patterns"] == "YYYY" for row in reader)
+    assert all(row["pattern_detected"] == "true" for row in reader)
+    assert set(row["perspective"] for row in reader) == {"horizontal", "vertical"}
+    assert set(reader[0].keys()) == {
+        "user_id",
+        "assignment_id",
+        "comment_id",
+        "prompt_id",
+        "timestamp",
+        "perspective",
+        "patterns",
+        "pattern_detected",
+        "pattern_coverage",
+    }
+
+
+def test_pattern_coverage_partial_window():
+    base_assignments = _build_uniform_yes_assignments(count=18)
+    tagger = Tagger(id="worker-1", tagassignments=base_assignments)
+    report = PatternDetectionReport(base_assignments)
+
+    data = report.generate_assignment_report([tagger], [])
+    coverage = data["horizontal"]["assignments"][0]["pattern_coverage"]
+
+    assert coverage == 66.67


### PR DESCRIPTION
## Summary
- compute pattern coverage percentage per user/assignment pair and include it in pattern report outputs and CSV
- document the new pattern coverage percentage column for the assignment pattern report
- extend pattern detection tests to validate coverage calculations and CSV schema

## Testing
- python -m pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ccf1e94f4833391c3653e74d52f6b)