### PR TITLE
Remove comment and pattern identifiers from pattern detection CSV

### DIFF
--- a/docs/REPORTS.md
+++ b/docs/REPORTS.md
@@ -139,9 +139,11 @@ and the pattern/speed columns are emitted.
 
 - `tagger_id`, `assignment_id` – the tagger and assignment identifiers; only
   assignment `1205` rows are written.
-- `# Tags Available` – total number of answer tags present for the
-  tagger/assignment pair, including those tagged as `0`/`SKIP` or other values
-  outside the YES/NO set used for pattern detection.
+- `# Tags Available` – maximum possible tags for the tagger/assignment pair,
+  summed per answer using the questionnaire's tag capacity (for example,
+  questionnaire `753` contributes 2 tags per answer and `754` contributes 1),
+  including answers tagged as `0`/`SKIP` or other values outside the YES/NO set
+  used for pattern detection.
 - `# Tags Set` – number of eligible timestamped YES/NO tags examined for the
   tagger/assignment pair (the input to pattern detection).
 - `# Tags Set in a pattern` – count of those eligible tags that fell within at

--- a/docs/REPORTS.md
+++ b/docs/REPORTS.md
@@ -108,11 +108,10 @@ of its timestamped YES/NO tags belong to a detected pattern window, how many
 tags land inside patterns, the total tags examined, how many answers were
 tagged in the assignment, and the tagging speed metrics for that assignment.
 
-The report returns a single entry for every tagger/assignment pair with
-metadata about the first tag (assignment/tags/group identifiers and earliest
-timestamp) plus the pattern(s) found when scanning that assignment's answer
-tags. Patterns are detected in 12-assignment windows using the same 3- and
-4-token repeat logic as `TaggerPerformanceReport`.
+The report returns a single entry for every tagger/assignment pair with the
+assignment identifiers and pattern(s) found when scanning that assignment's
+answer tags. Patterns are detected in 12-assignment windows using the same 3-
+and 4-token repeat logic as `TaggerPerformanceReport`.
 
 CSV exports include one row per assignment with a semicolon-delimited
 `detected_patterns` column (empty when no patterns were detected) and a boolean
@@ -139,11 +138,6 @@ and the pattern/speed columns are emitted.
 
 - `tagger_id`, `assignment_id` – the tagger and assignment identifiers; only
   assignment `1205` rows are written.
-- `first_prompt_id` – the prompt identifier from the first eligible tag in the
-  assignment, to anchor the row back to the source data. If the prompt is
-  missing in the source data the column is empty.
-- `first_tag_timestamp` – the earliest timestamp among the assignment's
-  eligible tags.
 - `eligible_tag_count` – number of eligible timestamped YES/NO tags examined for
   the tagger/assignment pair (the input to pattern detection).
 - `tags_in_pattern_count` – count of those eligible tags that fell within at

--- a/docs/REPORTS.md
+++ b/docs/REPORTS.md
@@ -138,12 +138,12 @@ and the pattern/speed columns are emitted.
 
 - `tagger_id`, `assignment_id` – the tagger and assignment identifiers; only
   assignment `1205` rows are written.
-- `eligible_tag_count` – number of eligible timestamped YES/NO tags examined for
-  the tagger/assignment pair (the input to pattern detection).
-- `tags_in_pattern_count` – count of those eligible tags that fell within at
+- `# Tags Set` – number of eligible timestamped YES/NO tags examined for the
+  tagger/assignment pair (the input to pattern detection).
+- `# Tags Set in a pattern` – count of those eligible tags that fell within at
   least one detected pattern window.
-- `distinct_answer_count` – number of distinct answers (comment IDs) tagged by
-  the user for the assignment.
+- `# Comments available to tag` – number of distinct answers (comment IDs)
+  tagged by the user for the assignment.
 - `detected_patterns` – semicolon-delimited list of patterns that hit within the
   assignment; empty when no pattern was detected for that row.
 - `has_repeating_pattern` – `true` when any pattern was found for that

--- a/docs/REPORTS.md
+++ b/docs/REPORTS.md
@@ -140,11 +140,12 @@ and the pattern/speed columns are emitted.
 - `tagger_id`, `assignment_id` – the tagger and assignment identifiers; only
   assignment `1205` rows are written.
 - `# Tags Available` – maximum possible tags for the tagger/assignment pair,
-  summed per answered question only when its `questionnaire_id` is `753` (2 tags
-  per answer) or `754` (1 tag per answer). Answers tied to other questionnaires
-  are ignored. Skipped answers still contribute to this availability total when
-  their questionnaire is counted, even though they are ineligible for pattern
-  detection.
+  summed per answered question by resolving the answer's `question_id` to its
+  parent questionnaire. Only questionnaires `753` (2 tags per answer) and `754`
+  (1 tag per answer) contribute to this total; answers tied to other
+  questionnaires are ignored. Skipped answers still contribute to this
+  availability total when their questionnaire is counted, even though they are
+  ineligible for pattern detection.
 - `# Tags Set` – number of eligible timestamped YES/NO tags examined for the
   tagger/assignment pair (the input to pattern detection).
 - `# Tags Set in a pattern` – count of those eligible tags that fell within at

--- a/docs/REPORTS.md
+++ b/docs/REPORTS.md
@@ -139,9 +139,9 @@ and the pattern/speed columns are emitted.
 
 - `tagger_id`, `assignment_id` – the tagger and assignment identifiers; only
   assignment `1205` rows are written.
-- `first_comment_id`, `first_prompt_id` – the comment and prompt identifiers
-  from the first eligible tag in the assignment, to anchor the row back to the
-  source data. If the prompt is missing in the source data the column is empty.
+- `first_prompt_id` – the prompt identifier from the first eligible tag in the
+  assignment, to anchor the row back to the source data. If the prompt is
+  missing in the source data the column is empty.
 - `first_tag_timestamp` – the earliest timestamp among the assignment's
   eligible tags.
 - `eligible_tag_count` – number of eligible timestamped YES/NO tags examined for

--- a/docs/REPORTS.md
+++ b/docs/REPORTS.md
@@ -106,7 +106,8 @@ an `assignment_id`). Only assignment `1205` is emitted in the report. In
 addition to the detected patterns, each assignment row reports what percentage
 of its timestamped YES/NO tags belong to a detected pattern window, how many
 tags land inside patterns, the total tags examined, how many answers were
-tagged in the assignment, and the tagging speed metrics for that assignment.
+tagged in the assignment, how many answer tags were present overall, and the
+tagging speed metrics for that assignment.
 
 The report returns a single entry for every tagger/assignment pair with the
 assignment identifiers and pattern(s) found when scanning that assignment's
@@ -138,6 +139,9 @@ and the pattern/speed columns are emitted.
 
 - `tagger_id`, `assignment_id` – the tagger and assignment identifiers; only
   assignment `1205` rows are written.
+- `# Tags Available` – total number of answer tags present for the
+  tagger/assignment pair, including those tagged as `0`/`SKIP` or other values
+  outside the YES/NO set used for pattern detection.
 - `# Tags Set` – number of eligible timestamped YES/NO tags examined for the
   tagger/assignment pair (the input to pattern detection).
 - `# Tags Set in a pattern` – count of those eligible tags that fell within at

--- a/docs/REPORTS.md
+++ b/docs/REPORTS.md
@@ -140,10 +140,11 @@ and the pattern/speed columns are emitted.
 - `tagger_id`, `assignment_id` – the tagger and assignment identifiers; only
   assignment `1205` rows are written.
 - `# Tags Available` – maximum possible tags for the tagger/assignment pair,
-  summed per answer using the questionnaire's tag capacity (for example,
-  questionnaire `753` contributes 2 tags per answer and `754` contributes 1),
-  including answers tagged as `0`/`SKIP` or other values outside the YES/NO set
-  used for pattern detection.
+  summed per answered question only when its `questionnaire_id` is `753` (2 tags
+  per answer) or `754` (1 tag per answer). Answers tied to other questionnaires
+  are ignored. Skipped answers still contribute to this availability total when
+  their questionnaire is counted, even though they are ineligible for pattern
+  detection.
 - `# Tags Set` – number of eligible timestamped YES/NO tags examined for the
   tagger/assignment pair (the input to pattern detection).
 - `# Tags Set in a pattern` – count of those eligible tags that fell within at

--- a/src/qcc/domain/tagassignment.py
+++ b/src/qcc/domain/tagassignment.py
@@ -32,6 +32,8 @@ class TagAssignment:
     assignment_id: Optional[str] = None
     prompt_id: Optional[str] = None
     team_id: Optional[str] = None
+    question_id: Optional[str] = None
+    questionnaire_id: Optional[str] = None
     
     def __post_init__(self) -> None:
         """Validate the tag assignment."""

--- a/src/qcc/reports/pattern_detection_report.py
+++ b/src/qcc/reports/pattern_detection_report.py
@@ -411,9 +411,9 @@ class PatternDetectionReport:
 
     def _questionnaire_tag_capacity(self, questionnaire_id: Optional[str]) -> int:
         if questionnaire_id in (None, ""):
-            return 1
+            return 0
 
-        return self.QUESTIONNAIRE_TAG_CAPACITY.get(str(questionnaire_id), 1)
+        return self.QUESTIONNAIRE_TAG_CAPACITY.get(str(questionnaire_id), 0)
 
     @staticmethod
     def _assignment_context(

--- a/src/qcc/reports/pattern_detection_report.py
+++ b/src/qcc/reports/pattern_detection_report.py
@@ -75,9 +75,9 @@ class PatternDetectionReport:
         fieldnames = [
             "tagger_id",
             "assignment_id",
-            "eligible_tag_count",
-            "tags_in_pattern_count",
-            "distinct_answer_count",
+            "# Tags Set",
+            "# Tags Set in a pattern",
+            "# Comments available to tag",
             "detected_patterns",
             "has_repeating_pattern",
             "pattern_coverage_pct",
@@ -252,9 +252,9 @@ class PatternDetectionReport:
             {
                 "tagger_id": str(first.tagger_id),
                 "assignment_id": assignment_id,
-                "eligible_tag_count": tag_count,
-                "tags_in_pattern_count": pattern_tag_count,
-                "distinct_answer_count": answer_count,
+                "# Tags Set": tag_count,
+                "# Tags Set in a pattern": pattern_tag_count,
+                "# Comments available to tag": answer_count,
                 "detected_patterns": patterns,
                 "has_repeating_pattern": bool(patterns),
                 "pattern_coverage_pct": coverage,
@@ -322,14 +322,12 @@ class PatternDetectionReport:
             row: MutableMapping[str, str] = {
                 "tagger_id": str(assignment.get("tagger_id", "")),
                 "assignment_id": str(assignment.get("assignment_id", "") or ""),
-                "eligible_tag_count": str(
-                    assignment.get("eligible_tag_count", "") or ""
+                "# Tags Set": str(assignment.get("# Tags Set", "") or ""),
+                "# Tags Set in a pattern": str(
+                    assignment.get("# Tags Set in a pattern", "") or ""
                 ),
-                "tags_in_pattern_count": str(
-                    assignment.get("tags_in_pattern_count", "") or ""
-                ),
-                "distinct_answer_count": str(
-                    assignment.get("distinct_answer_count", "") or ""
+                "# Comments available to tag": str(
+                    assignment.get("# Comments available to tag", "") or ""
                 ),
                 "detected_patterns": pattern_str,
                 "has_repeating_pattern": str(bool(patterns)).lower(),

--- a/src/qcc/reports/pattern_detection_report.py
+++ b/src/qcc/reports/pattern_detection_report.py
@@ -25,6 +25,7 @@ class PatternDetectionReport:
     """Generate per-assignment pattern detection results."""
 
     TARGET_ASSIGNMENT_ID = "1205"
+    QUESTIONNAIRE_TAG_CAPACITY = {"753": 2, "754": 1}
 
     def __init__(self, assignments: Sequence[TagAssignment]) -> None:
         self.assignments: List[TagAssignment] = list(assignments or [])
@@ -240,7 +241,12 @@ class PatternDetectionReport:
             eligible_assignments, windows
         )
         _, seconds_per_tag = self._speed_metrics(eligible_assignments)
-        available_tag_count = len(assignments)
+        available_tag_count = sum(
+            self._questionnaire_tag_capacity(
+                getattr(assignment, "questionnaire_id", None)
+            )
+            for assignment in assignments
+        )
         tag_count = len(eligible_assignments)
         answer_count = len(
             {
@@ -402,6 +408,12 @@ class PatternDetectionReport:
         mean_log2 = strategy.speed_log2(tagger)
         seconds = strategy.seconds_per_tag(mean_log2)
         return round(mean_log2, 6), round(seconds, 6)
+
+    def _questionnaire_tag_capacity(self, questionnaire_id: Optional[str]) -> int:
+        if questionnaire_id in (None, ""):
+            return 1
+
+        return self.QUESTIONNAIRE_TAG_CAPACITY.get(str(questionnaire_id), 1)
 
     @staticmethod
     def _assignment_context(

--- a/src/qcc/reports/pattern_detection_report.py
+++ b/src/qcc/reports/pattern_detection_report.py
@@ -76,7 +76,6 @@ class PatternDetectionReport:
         fieldnames = [
             "tagger_id",
             "assignment_id",
-            "first_comment_id",
             "first_prompt_id",
             "first_tag_timestamp",
             "eligible_tag_count",
@@ -257,7 +256,6 @@ class PatternDetectionReport:
             {
                 "tagger_id": str(first.tagger_id),
                 "assignment_id": assignment_id,
-                "first_comment_id": getattr(first, "comment_id", None),
                 "first_prompt_id": getattr(first, "prompt_id", None),
                 "first_tag_timestamp": self._timestamp_str(timestamp),
                 "eligible_tag_count": tag_count,
@@ -330,9 +328,6 @@ class PatternDetectionReport:
             row: MutableMapping[str, str] = {
                 "tagger_id": str(assignment.get("tagger_id", "")),
                 "assignment_id": str(assignment.get("assignment_id", "") or ""),
-                "first_comment_id": str(
-                    assignment.get("first_comment_id", "") or ""
-                ),
                 "first_prompt_id": str(
                     assignment.get("first_prompt_id", "") or ""
                 ),

--- a/src/qcc/reports/pattern_detection_report.py
+++ b/src/qcc/reports/pattern_detection_report.py
@@ -327,6 +327,12 @@ class PatternDetectionReport:
         assignments: Iterable[Mapping[str, object]],
     ) -> List[Dict[str, str]]:
         rows: List[Dict[str, str]] = []
+
+        def _stringify(value: object) -> str:
+            if value is None:
+                return ""
+            return str(value)
+
         for assignment in assignments:
             if not isinstance(assignment, Mapping):
                 logger.warning(
@@ -336,25 +342,25 @@ class PatternDetectionReport:
             patterns = assignment.get("detected_patterns", []) or []
             pattern_str = ";".join(patterns) if patterns else ""
             row: MutableMapping[str, str] = {
-                "tagger_id": str(assignment.get("tagger_id", "")),
-                "assignment_id": str(assignment.get("assignment_id", "") or ""),
-                "# Tags Available": str(
-                    assignment.get("# Tags Available", "") or ""
+                "tagger_id": _stringify(assignment.get("tagger_id", "")),
+                "assignment_id": _stringify(assignment.get("assignment_id", "")),
+                "# Tags Available": _stringify(
+                    assignment.get("# Tags Available", "")
                 ),
-                "# Tags Set": str(assignment.get("# Tags Set", "") or ""),
-                "# Tags Set in a pattern": str(
-                    assignment.get("# Tags Set in a pattern", "") or ""
+                "# Tags Set": _stringify(assignment.get("# Tags Set", "")),
+                "# Tags Set in a pattern": _stringify(
+                    assignment.get("# Tags Set in a pattern", "")
                 ),
-                "# Comments available to tag": str(
-                    assignment.get("# Comments available to tag", "") or ""
+                "# Comments available to tag": _stringify(
+                    assignment.get("# Comments available to tag", "")
                 ),
                 "detected_patterns": pattern_str,
                 "has_repeating_pattern": str(bool(patterns)).lower(),
-                "pattern_coverage_pct": str(
-                    assignment.get("pattern_coverage_pct", "") or ""
+                "pattern_coverage_pct": _stringify(
+                    assignment.get("pattern_coverage_pct", "")
                 ),
-                "trimmed_seconds_per_tag": str(
-                    assignment.get("trimmed_seconds_per_tag", "") or ""
+                "trimmed_seconds_per_tag": _stringify(
+                    assignment.get("trimmed_seconds_per_tag", "")
                 ),
             }
 

--- a/src/qcc/reports/pattern_detection_report.py
+++ b/src/qcc/reports/pattern_detection_report.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import csv
 import logging
-from datetime import datetime
 from pathlib import Path
 from typing import Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence
 
@@ -76,8 +75,6 @@ class PatternDetectionReport:
         fieldnames = [
             "tagger_id",
             "assignment_id",
-            "first_prompt_id",
-            "first_tag_timestamp",
             "eligible_tag_count",
             "tags_in_pattern_count",
             "distinct_answer_count",
@@ -237,7 +234,6 @@ class PatternDetectionReport:
             return []
 
         first = assignments[0]
-        timestamp = getattr(first, "timestamp", None)
         patterns = sorted({pattern for _, pattern in windows})
         coverage, pattern_tag_count = self._pattern_coverage_stats(
             eligible_assignments, windows
@@ -256,8 +252,6 @@ class PatternDetectionReport:
             {
                 "tagger_id": str(first.tagger_id),
                 "assignment_id": assignment_id,
-                "first_prompt_id": getattr(first, "prompt_id", None),
-                "first_tag_timestamp": self._timestamp_str(timestamp),
                 "eligible_tag_count": tag_count,
                 "tags_in_pattern_count": pattern_tag_count,
                 "distinct_answer_count": answer_count,
@@ -328,12 +322,6 @@ class PatternDetectionReport:
             row: MutableMapping[str, str] = {
                 "tagger_id": str(assignment.get("tagger_id", "")),
                 "assignment_id": str(assignment.get("assignment_id", "") or ""),
-                "first_prompt_id": str(
-                    assignment.get("first_prompt_id", "") or ""
-                ),
-                "first_tag_timestamp": str(
-                    assignment.get("first_tag_timestamp", "") or ""
-                ),
                 "eligible_tag_count": str(
                     assignment.get("eligible_tag_count", "") or ""
                 ),
@@ -381,10 +369,6 @@ class PatternDetectionReport:
             eligible.append(assignment)
 
         return sorted(eligible, key=lambda assignment: assignment.timestamp)
-
-    @staticmethod
-    def _timestamp_str(timestamp: Optional[datetime]) -> str:
-        return timestamp.isoformat() if isinstance(timestamp, datetime) else ""
 
     @staticmethod
     def _pattern_coverage_stats(

--- a/src/qcc/reports/pattern_detection_report.py
+++ b/src/qcc/reports/pattern_detection_report.py
@@ -75,6 +75,7 @@ class PatternDetectionReport:
         fieldnames = [
             "tagger_id",
             "assignment_id",
+            "# Tags Available",
             "# Tags Set",
             "# Tags Set in a pattern",
             "# Comments available to tag",
@@ -239,6 +240,7 @@ class PatternDetectionReport:
             eligible_assignments, windows
         )
         _, seconds_per_tag = self._speed_metrics(eligible_assignments)
+        available_tag_count = len(assignments)
         tag_count = len(eligible_assignments)
         answer_count = len(
             {
@@ -252,6 +254,7 @@ class PatternDetectionReport:
             {
                 "tagger_id": str(first.tagger_id),
                 "assignment_id": assignment_id,
+                "# Tags Available": available_tag_count,
                 "# Tags Set": tag_count,
                 "# Tags Set in a pattern": pattern_tag_count,
                 "# Comments available to tag": answer_count,
@@ -322,6 +325,9 @@ class PatternDetectionReport:
             row: MutableMapping[str, str] = {
                 "tagger_id": str(assignment.get("tagger_id", "")),
                 "assignment_id": str(assignment.get("assignment_id", "") or ""),
+                "# Tags Available": str(
+                    assignment.get("# Tags Available", "") or ""
+                ),
                 "# Tags Set": str(assignment.get("# Tags Set", "") or ""),
                 "# Tags Set in a pattern": str(
                     assignment.get("# Tags Set in a pattern", "") or ""

--- a/tests/test_db_adapter.py
+++ b/tests/test_db_adapter.py
@@ -122,8 +122,12 @@ def test_db_adapter_merges_answers_with_tags():
     assert len(assignments) == 2
     assert assignments[0].comment_id == "101"
     assert assignments[0].value == TagValue.YES
+    assert assignments[0].question_id == "7"
+    assert assignments[0].questionnaire_id == "88"
     assert assignments[1].comment_id == "102"
     assert assignments[1].value == TagValue.SKIP
+    assert assignments[1].question_id == "8"
+    assert assignments[1].questionnaire_id == "88"
 
     comments = {comment.id: comment for comment in domain_objects["comments"]}
     assert comments["101"].text == "First answer"

--- a/tests/test_pattern_detection_report.py
+++ b/tests/test_pattern_detection_report.py
@@ -141,6 +141,22 @@ def test_csv_export_deduplicates_vertical_rows(tmp_path):
     assert len(rows) == 1
 
 
+def test_csv_export_shows_zero_tag_availability(tmp_path):
+    assignments = _build_uniform_yes_assignments(questionnaire_id="999")
+    tagger = Tagger(id="worker-0", tagassignments=assignments)
+    report = PatternDetectionReport(assignments)
+
+    data = report.generate_assignment_report([tagger], [])
+    csv_path = tmp_path / "zero-availability.csv"
+    report.export_to_csv(data, csv_path)
+
+    with csv_path.open(newline="", encoding="utf-8") as csv_file:
+        rows = list(csv.DictReader(csv_file))
+
+    assert len(rows) == 1
+    assert rows[0]["# Tags Available"] == "0"
+
+
 def test_pattern_coverage_partial_window():
     base_assignments = _build_uniform_yes_assignments(count=18, questionnaire_id="753")
     tagger = Tagger(id="worker-1", tagassignments=base_assignments)

--- a/tests/test_pattern_detection_report.py
+++ b/tests/test_pattern_detection_report.py
@@ -80,8 +80,6 @@ def test_csv_export_writes_all_assignment_rows(tmp_path):
     assert set(reader[0].keys()) == {
         "tagger_id",
         "assignment_id",
-        "first_prompt_id",
-        "first_tag_timestamp",
         "eligible_tag_count",
         "tags_in_pattern_count",
         "distinct_answer_count",

--- a/tests/test_pattern_detection_report.py
+++ b/tests/test_pattern_detection_report.py
@@ -183,6 +183,48 @@ def test_available_tags_include_skips():
     assert horizontal["# Tags Set"] == 1
 
 
+def test_tags_available_uses_questionnaire_capacity():
+    start = datetime(2024, 1, 1, 0, 0, 0)
+    assignments = [
+        TagAssignment(
+            tagger_id="worker-1",
+            comment_id="comment-753-1",
+            characteristic_id="char-1",
+            value=TagValue.YES,
+            timestamp=start,
+            assignment_id="1205",
+            questionnaire_id="753",
+        ),
+        TagAssignment(
+            tagger_id="worker-1",
+            comment_id="comment-753-2",
+            characteristic_id="char-1",
+            value=TagValue.SKIP,
+            timestamp=start + timedelta(seconds=1),
+            assignment_id="1205",
+            questionnaire_id="753",
+        ),
+        TagAssignment(
+            tagger_id="worker-1",
+            comment_id="comment-754",
+            characteristic_id="char-1",
+            value=TagValue.NO,
+            timestamp=start + timedelta(seconds=2),
+            assignment_id="1205",
+            questionnaire_id="754",
+        ),
+    ]
+
+    report = PatternDetectionReport(assignments)
+    data = report.generate_assignment_report([Tagger(id="worker-1", tagassignments=assignments)], [])
+    horizontal = data["horizontal"]["assignments"][0]
+
+    # questionnaire_id 753 allows 2 tags per answer and 754 allows 1
+    assert horizontal["# Tags Available"] == 5
+    assert horizontal["# Tags Set"] == 2
+    assert horizontal["# Comments available to tag"] == 3
+
+
 def test_csv_rows_sorted_by_user_id(tmp_path):
     assignments_a = _build_uniform_yes_assignments(assignment_id="1205")
     tagger_a = Tagger(id="user-1", tagassignments=assignments_a)

--- a/tests/test_pattern_detection_report.py
+++ b/tests/test_pattern_detection_report.py
@@ -42,9 +42,9 @@ def test_horizontal_assignments_capture_pattern_window():
     assert horizontal[0]["has_repeating_pattern"] is True
     assert horizontal[0]["assignment_id"] == "1205"
     assert horizontal[0]["pattern_coverage_pct"] == 100.0
-    assert horizontal[0]["eligible_tag_count"] == 12
-    assert horizontal[0]["tags_in_pattern_count"] == 12
-    assert horizontal[0]["distinct_answer_count"] == 12
+    assert horizontal[0]["# Tags Set"] == 12
+    assert horizontal[0]["# Tags Set in a pattern"] == 12
+    assert horizontal[0]["# Comments available to tag"] == 12
     assert horizontal[0]["trimmed_seconds_per_tag"] == 1.0
 
 
@@ -80,9 +80,9 @@ def test_csv_export_writes_all_assignment_rows(tmp_path):
     assert set(reader[0].keys()) == {
         "tagger_id",
         "assignment_id",
-        "eligible_tag_count",
-        "tags_in_pattern_count",
-        "distinct_answer_count",
+        "# Tags Set",
+        "# Tags Set in a pattern",
+        "# Comments available to tag",
         "detected_patterns",
         "has_repeating_pattern",
         "pattern_coverage_pct",
@@ -141,8 +141,8 @@ def test_pattern_coverage_partial_window():
 
     data = report.generate_assignment_report([tagger], [])
     coverage = data["horizontal"]["assignments"][0]["pattern_coverage_pct"]
-    pattern_tag_count = data["horizontal"]["assignments"][0]["tags_in_pattern_count"]
-    tag_count = data["horizontal"]["assignments"][0]["eligible_tag_count"]
+    pattern_tag_count = data["horizontal"]["assignments"][0]["# Tags Set in a pattern"]
+    tag_count = data["horizontal"]["assignments"][0]["# Tags Set"]
 
     assert coverage == 66.67
     assert pattern_tag_count == 12

--- a/tests/test_pattern_detection_report.py
+++ b/tests/test_pattern_detection_report.py
@@ -80,7 +80,6 @@ def test_csv_export_writes_all_assignment_rows(tmp_path):
     assert set(reader[0].keys()) == {
         "tagger_id",
         "assignment_id",
-        "first_comment_id",
         "first_prompt_id",
         "first_tag_timestamp",
         "eligible_tag_count",
@@ -91,6 +90,7 @@ def test_csv_export_writes_all_assignment_rows(tmp_path):
         "pattern_coverage_pct",
         "trimmed_seconds_per_tag",
     }
+    assert "pattern_id" not in reader[0]
 
 
 def test_csv_export_deduplicates_vertical_rows(tmp_path):

--- a/tests/test_pattern_detection_report.py
+++ b/tests/test_pattern_detection_report.py
@@ -201,6 +201,7 @@ def test_tags_available_uses_questionnaire_capacity():
             timestamp=start,
             assignment_id="1205",
             questionnaire_id="753",
+            question_id="question-753-a",
         ),
         TagAssignment(
             tagger_id="worker-1",
@@ -210,6 +211,7 @@ def test_tags_available_uses_questionnaire_capacity():
             timestamp=start + timedelta(seconds=1),
             assignment_id="1205",
             questionnaire_id="753",
+            question_id="question-753-b",
         ),
         TagAssignment(
             tagger_id="worker-1",
@@ -219,6 +221,7 @@ def test_tags_available_uses_questionnaire_capacity():
             timestamp=start + timedelta(seconds=2),
             assignment_id="1205",
             questionnaire_id="754",
+            question_id="question-754",
         ),
         TagAssignment(
             tagger_id="worker-1",
@@ -228,6 +231,7 @@ def test_tags_available_uses_questionnaire_capacity():
             timestamp=start + timedelta(seconds=3),
             assignment_id="1205",
             questionnaire_id="9999",
+            question_id="question-other",
         ),
     ]
 
@@ -239,6 +243,42 @@ def test_tags_available_uses_questionnaire_capacity():
     assert horizontal["# Tags Available"] == 5
     assert horizontal["# Tags Set"] == 2
     assert horizontal["# Comments available to tag"] == 4
+
+
+def test_tags_available_backfills_questionnaire_from_question_lookup():
+    start = datetime(2024, 1, 1, 0, 0, 0)
+    assignments = [
+        TagAssignment(
+            tagger_id="worker-1",
+            comment_id="comment-with-questionnaire",
+            characteristic_id="char-1",
+            value=TagValue.YES,
+            timestamp=start,
+            assignment_id="1205",
+            questionnaire_id="753",
+            question_id="question-shared",
+        ),
+        TagAssignment(
+            tagger_id="worker-1",
+            comment_id="comment-without-questionnaire",
+            characteristic_id="char-1",
+            value=TagValue.NO,
+            timestamp=start + timedelta(seconds=1),
+            assignment_id="1205",
+            questionnaire_id=None,
+            question_id="question-shared",
+        ),
+    ]
+
+    report = PatternDetectionReport(assignments)
+    data = report.generate_assignment_report(
+        [Tagger(id="worker-1", tagassignments=assignments)], []
+    )
+    horizontal = data["horizontal"]["assignments"][0]
+
+    assert horizontal["# Tags Available"] == 4
+    assert horizontal["# Tags Set"] == 2
+    assert horizontal["# Comments available to tag"] == 2
 
 
 def test_csv_rows_sorted_by_user_id(tmp_path):


### PR DESCRIPTION
## Summary
- stop emitting comment and pattern identifier columns from the pattern detection CSV export
- update documentation to reflect the reduced assignment-level fields
- adjust pattern detection report tests to expect the pared-down column set

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f7c2fc58c8333ba7fae48c0bb6cf2)