### PR TITLE
Add fallback capacity for unknown questionnaires

### DIFF
--- a/src/qcc/reports/pattern_detection_report.py
+++ b/src/qcc/reports/pattern_detection_report.py
@@ -26,6 +26,7 @@ class PatternDetectionReport:
 
     TARGET_ASSIGNMENT_ID = "1205"
     QUESTIONNAIRE_TAG_CAPACITY = {"753": 2, "754": 1}
+    DEFAULT_TAG_CAPACITY = 1
 
     def __init__(self, assignments: Sequence[TagAssignment]) -> None:
         self.assignments: List[TagAssignment] = list(assignments or [])
@@ -419,9 +420,23 @@ class PatternDetectionReport:
 
     def _questionnaire_tag_capacity(self, questionnaire_id: Optional[str]) -> int:
         if questionnaire_id in (None, ""):
-            return 0
+            logger.warning(
+                "Missing questionnaire_id when computing tag availability; defaulting to %s",
+                self.DEFAULT_TAG_CAPACITY,
+            )
+            return self.DEFAULT_TAG_CAPACITY
 
-        return self.QUESTIONNAIRE_TAG_CAPACITY.get(str(questionnaire_id), 0)
+        questionnaire_id_str = str(questionnaire_id)
+        capacity = self.QUESTIONNAIRE_TAG_CAPACITY.get(questionnaire_id_str)
+        if capacity is None:
+            logger.warning(
+                "Unknown questionnaire_id %s when computing tag availability; defaulting to %s",
+                questionnaire_id_str,
+                self.DEFAULT_TAG_CAPACITY,
+            )
+            return self.DEFAULT_TAG_CAPACITY
+
+        return capacity
 
     def _available_tags_for_assignments(
         self, assignments: Sequence[TagAssignment]

--- a/tests/test_pattern_detection_report.py
+++ b/tests/test_pattern_detection_report.py
@@ -141,7 +141,7 @@ def test_csv_export_deduplicates_vertical_rows(tmp_path):
     assert len(rows) == 1
 
 
-def test_csv_export_shows_zero_tag_availability(tmp_path):
+def test_csv_export_defaults_tag_availability(tmp_path):
     assignments = _build_uniform_yes_assignments(questionnaire_id="999")
     tagger = Tagger(id="worker-0", tagassignments=assignments)
     report = PatternDetectionReport(assignments)
@@ -154,7 +154,7 @@ def test_csv_export_shows_zero_tag_availability(tmp_path):
         rows = list(csv.DictReader(csv_file))
 
     assert len(rows) == 1
-    assert rows[0]["# Tags Available"] == "0"
+    assert rows[0]["# Tags Available"] == "12"
 
 
 def test_pattern_coverage_partial_window():
@@ -255,8 +255,9 @@ def test_tags_available_uses_questionnaire_capacity():
     data = report.generate_assignment_report([Tagger(id="worker-1", tagassignments=assignments)], [])
     horizontal = data["horizontal"]["assignments"][0]
 
-    # questionnaire_id 753 allows 2 tags per answer and 754 allows 1
-    assert horizontal["# Tags Available"] == 5
+    # questionnaire_id 753 allows 2 tags per answer, 754 allows 1, and unknown
+    # questionnaires default to the minimal capacity
+    assert horizontal["# Tags Available"] == 6
     assert horizontal["# Tags Set"] == 2
     assert horizontal["# Comments available to tag"] == 4
 
@@ -296,6 +297,34 @@ def test_tags_available_counts_unique_comments():
     assert horizontal["# Tags Available"] == 2
     assert horizontal["# Tags Set"] == 2
     assert horizontal["# Comments available to tag"] == 1
+
+
+def test_tags_available_defaults_capacity_for_missing_questionnaire(caplog):
+    start = datetime(2024, 1, 1, 0, 0, 0)
+    assignments = [
+        TagAssignment(
+            tagger_id="worker-1",
+            comment_id="comment-without-questionnaire",
+            characteristic_id="char-1",
+            value=TagValue.YES,
+            timestamp=start,
+            assignment_id="1205",
+            questionnaire_id=None,
+            question_id="question-without-questionnaire",
+        )
+    ]
+
+    report = PatternDetectionReport(assignments)
+    with caplog.at_level(logging.WARNING):
+        data = report.generate_assignment_report(
+            [Tagger(id="worker-1", tagassignments=assignments)], []
+        )
+
+    horizontal = data["horizontal"]["assignments"][0]
+
+    assert horizontal["# Tags Available"] == 1
+    assert horizontal["# Comments available to tag"] == 1
+    assert any("defaulting" in record.message for record in caplog.records)
 
 
 def test_tags_available_backfills_questionnaire_from_question_lookup():


### PR DESCRIPTION
## Summary
- default questionnaire tag capacity to a minimal value when the ID is missing or unrecognized, logging a warning
- adjust availability calculations to count unknown questionnaires instead of zeroing them
- update pattern detection report tests to cover the new fallback behavior

## Testing
- pytest tests/test_pattern_detection_report.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920d67830e48333930a5511f625eb48)