### PR TITLE
Add MySQL helpers to recalc pattern detection availability

### DIFF
--- a/src/qcc/reports/pattern_detection_report.py
+++ b/src/qcc/reports/pattern_detection_report.py
@@ -497,11 +497,12 @@ class PatternDetectionReport:
         """Return a mapping of tagger_id to team_id for the target assignment."""
 
         query = """
-            SELECT assignment_view.user_id AS tagger_id, team_view.team_id AS team_id
-            FROM assignment_team_views AS assignment_view
-            INNER JOIN team_views AS team_view
-                ON assignment_view.team_id = team_view.team_id
-            WHERE assignment_view.assignment_id = %s
+            SELECT v1.user_id AS tagger_id, v2.team_id AS team_id
+            FROM view1 v1
+            INNER JOIN view2 v2
+                ON v1.user_id = v2.user_id
+               AND v1.assignment_id = v2.assignment_id
+            WHERE v1.assignment_id = %s
         """
 
         tagger_team_map: Dict[str, str] = {}

--- a/src/qcc/reports/pattern_detection_report.py
+++ b/src/qcc/reports/pattern_detection_report.py
@@ -85,6 +85,7 @@ class PatternDetectionReport:
         rows = self._build_csv_rows(report_data)
         fieldnames = [
             "tagger_id",
+            "team_id",
             "assignment_id",
             "# Tags Available",
             "# Tags Set",
@@ -341,6 +342,7 @@ class PatternDetectionReport:
             pattern_str = ";".join(patterns) if patterns else ""
             row: MutableMapping[str, str] = {
                 "tagger_id": _stringify(assignment.get("tagger_id", "")),
+                "team_id": _stringify(assignment.get("team_id", "")),
                 "assignment_id": _stringify(assignment.get("assignment_id", "")),
                 "# Tags Available": _stringify(
                     assignment.get("# Tags Available", "")

--- a/src/qcc/reports/pattern_detection_report.py
+++ b/src/qcc/reports/pattern_detection_report.py
@@ -43,6 +43,10 @@ class PatternDetectionReport:
     ) -> Dict[str, object]:
         """Return pattern detection results for every assignment a user tagged."""
 
+        print(
+            f"Questionnaire map for assignment {self.TARGET_ASSIGNMENT_ID}: "
+            f"{self._questionnaire_by_question}"
+        )
         logger.info(
             "Questionnaire map for assignment %s: %s",
             self.TARGET_ASSIGNMENT_ID,

--- a/tests/test_pattern_detection_report.py
+++ b/tests/test_pattern_detection_report.py
@@ -83,6 +83,7 @@ def test_csv_export_writes_all_assignment_rows(tmp_path):
     assert all(row["has_repeating_pattern"] == "true" for row in reader)
     assert set(reader[0].keys()) == {
         "tagger_id",
+        "team_id",
         "assignment_id",
         "# Tags Available",
         "# Tags Set",


### PR DESCRIPTION
## Summary
- add MySQL queries to map taggers to teams and count submitted review answers for assignment 1205
- update CSV tag availability recalculation to include team_id and reuse the review answer counts when rewriting

## Testing
- pytest tests/test_pattern_detection_report.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69236782bc288333a17db1e6610d395b)