### PR TITLE
Propagate MySQL config to pattern report exports

### DIFF
--- a/src/qcc/reports/pattern_detection_report.py
+++ b/src/qcc/reports/pattern_detection_report.py
@@ -83,8 +83,19 @@ class PatternDetectionReport:
             },
         }
 
-    def export_to_csv(self, report_data: Mapping[str, object], output_path: Path) -> None:
-        """Export the per-assignment pattern results to CSV."""
+    def export_to_csv(
+        self,
+        report_data: Mapping[str, object],
+        output_path: Path,
+        mysql_config: MySQLConfig | None = None,
+    ) -> None:
+        """Export the per-assignment pattern results to CSV.
+
+        Args:
+            report_data: Assignment-level report data.
+            output_path: CSV destination.
+            mysql_config: Optional MySQL settings used to backfill assignment metadata.
+        """
 
         csv_path = Path(output_path)
         rows = self._build_csv_rows(report_data)
@@ -111,6 +122,9 @@ class PatternDetectionReport:
         logger.info(
             "Pattern detection CSV written to %s with %s rows", csv_path, len(rows)
         )
+
+        if mysql_config:
+            self._recalculate_csv_tag_availability(csv_path, mysql_config)
 
     def _build_horizontal_results(
         self, taggers: Sequence[Tagger], strategy: PatternSignalsStrategy

--- a/tests/test_cli_questionnaire_ingestion.py
+++ b/tests/test_cli_questionnaire_ingestion.py
@@ -21,9 +21,12 @@ def test_read_domain_objects_prefers_questionnaire_root(monkeypatch):
         format="mysql", mysql=MySQLInputConfig(dsn="mysql://user:pass@db/qcc")
     )
 
-    domain_objects, source = main._read_domain_objects(None, input_config)
+    domain_objects, source, mysql_config = main._read_domain_objects(
+        None, input_config
+    )
 
     assert domain_objects == {"assignments": ["questionnaire-rooted"]}
     assert source == "mysql://user:pass@db/qcc"
     assert captured["limit"] is None
+    assert mysql_config is captured["config"]
     assert captured["config"].database == "qcc"


### PR DESCRIPTION
## Summary
- return the constructed MySQL configuration from ingestion so it can be reused downstream
- plumb the optional MySQL config through pattern detection CSV exports and summary rewrites
- add coverage to ensure MySQL configs are forwarded from CLI ingestion

## Testing
- python -m pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69292375072c83339cd6788101a43273)