### PR TITLE
Add tag report helper utilities and tests (ID-based grouping)

### DIFF
--- a/src/qcc/reports/tag_report.py
+++ b/src/qcc/reports/tag_report.py
@@ -1,0 +1,139 @@
+"""Core utilities for tag-level reports.
+
+This module provides lightweight helper functions and a simple
+dataclass used by higher-level tag reporting tools.  It intentionally
+contains no I/O or CSV/export logic — those live in higher layers
+of the reporting system.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Dict, List, Tuple, Set, Optional
+
+from qcc.domain.tagassignment import TagAssignment
+from qcc.domain.characteristic import Characteristic
+from qcc.domain.enums import TagValue
+from qcc.metrics.agreement import AgreementMetrics
+
+
+@dataclass
+class TagReportRow:
+    comment_id: str
+    characteristic_id: str
+    num_taggers_could_set: int
+    num_yes: int
+    num_no: int
+    krippendorffs_alpha: Optional[float]
+    tag_quality: Optional[float] = None   # filled later by another component
+
+
+def group_by_comment(assignments: List[TagAssignment]) -> Dict[str, List[TagAssignment]]:
+    """Group assignments by comment_id (string key).
+
+    This function focuses on IDs only — it will look for a ``comment_id``
+    attribute on the assignment and fall back to an enriched ``comment.id``
+    when available. Assignments missing any comment id are skipped.
+    """
+
+    groups: Dict[str, List[TagAssignment]] = defaultdict(list)
+
+    for assignment in assignments or []:
+        cid = getattr(assignment, "comment_id", None)
+        if cid is None:
+            comment_obj = getattr(assignment, "comment", None)
+            cid = getattr(comment_obj, "id", None) if comment_obj is not None else None
+        if cid is None:
+            continue
+        groups[str(cid)].append(assignment)
+
+    return dict(groups)
+
+
+def group_by_comment_and_characteristic(
+    assignments: List[TagAssignment],
+) -> Dict[Tuple[str, str], List[TagAssignment]]:
+    """Group assignments by (comment_id, characteristic_id) tuple of strings.
+
+    This is explicitly ID-focused and does not attempt to create any
+    placeholder domain objects. If either id is missing the assignment is
+    skipped.
+    """
+
+    groups: Dict[Tuple[str, str], List[TagAssignment]] = defaultdict(list)
+
+    for assignment in assignments or []:
+        cid = getattr(assignment, "comment_id", None)
+        if cid is None:
+            comment_obj = getattr(assignment, "comment", None)
+            cid = getattr(comment_obj, "id", None) if comment_obj is not None else None
+        char_id = getattr(assignment, "characteristic_id", None)
+        if char_id is None:
+            char_obj = getattr(assignment, "characteristic", None)
+            char_id = getattr(char_obj, "id", None) if char_obj is not None else None
+
+        if cid is None or char_id is None:
+            continue
+
+        groups[(str(cid), str(char_id))].append(assignment)
+
+    return dict(groups)
+
+
+def taggers_who_touched_comment(assignments_for_comment: List[TagAssignment]) -> Set[str]:
+    """Return set of tagger_id strings of taggers who tagged this comment.
+
+    This function strictly returns IDs and does not construct or return
+    Tagger objects.
+    """
+
+    tagger_ids: Set[str] = set()
+    for assignment in assignments_for_comment or []:
+        tid = getattr(assignment, "tagger_id", None)
+        if tid is None:
+            tagger_obj = getattr(assignment, "tagger", None)
+            tid = getattr(tagger_obj, "id", None) if tagger_obj is not None else None
+        if tid is not None:
+            tagger_ids.add(str(tid))
+
+    return tagger_ids
+
+
+def count_yes_no(assignments: List[TagAssignment]) -> Tuple[int, int]:
+    """Return (#YES, #NO) based on TagValue.YES and TagValue.NO.
+
+    Non-YES/NO values are ignored.
+    """
+
+    yes = 0
+    no = 0
+
+    for assignment in assignments or []:
+        v = getattr(assignment, "value", None)
+        if v == TagValue.YES:
+            yes += 1
+        elif v == TagValue.NO:
+            no += 1
+
+    return yes, no
+
+
+def alpha_for_item(assignments: List[TagAssignment], characteristic: Characteristic) -> Optional[float]:
+    """Return Krippendorff’s alpha for a single (comment, characteristic).
+
+    Uses :class:`qcc.metrics.agreement.AgreementMetrics`. If fewer than two
+    distinct taggers participated on this item the function returns ``None``
+    to signify alpha is not defined.
+    """
+
+    if not assignments:
+        return None
+
+    # If fewer than 2 unique taggers, alpha is not meaningful
+    taggers = taggers_who_touched_comment(assignments)
+    if len(taggers) < 2:
+        return None
+
+    metrics = AgreementMetrics()
+    return metrics.krippendorffs_alpha(assignments, characteristic)

--- a/tests/test_reports_tag_report.py
+++ b/tests/test_reports_tag_report.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from datetime import datetime
+
+from qcc.reports.tag_report import (
+    group_by_comment,
+    group_by_comment_and_characteristic,
+    taggers_who_touched_comment,
+    count_yes_no,
+    alpha_for_item,
+    TagReportRow,
+)
+from qcc.domain.comment import Comment
+from qcc.domain.characteristic import Characteristic
+from qcc.domain.tagger import Tagger
+from qcc.domain.tagassignment import TagAssignment
+from qcc.domain.enums import TagValue
+
+
+def make_assignment(**kwargs):
+    # Simple helper to create a lightweight assignment-like object.
+    return SimpleNamespace(**kwargs)
+
+
+def test_group_by_comment_with_comment_objects():
+    c1 = Comment(id="c1", text="hello", prompt_id="p1", tagassignments=[])
+    c2 = Comment(id="c2", text="bye", prompt_id="p1", tagassignments=[])
+
+    a1 = make_assignment(comment=c1, comment_id="c1")
+    a2 = make_assignment(comment=c1, comment_id="c1")
+    a3 = make_assignment(comment=c2, comment_id="c2")
+
+    grouped = group_by_comment([a1, a2, a3])
+    assert set(grouped.keys()) == {"c1", "c2"}
+    assert len(grouped["c1"]) == 2
+    assert len(grouped["c2"]) == 1
+
+
+def test_group_by_comment_creates_placeholders_for_ids():
+    now = datetime.utcnow()
+    t1 = TagAssignment(tagger_id="u1", comment_id="c1", characteristic_id="ch", value=TagValue.YES, timestamp=now)
+    t2 = TagAssignment(tagger_id="u2", comment_id="c1", characteristic_id="ch", value=TagValue.NO, timestamp=now)
+    t3 = TagAssignment(tagger_id="u3", comment_id="c2", characteristic_id="ch", value=TagValue.YES, timestamp=now)
+
+    grouped = group_by_comment([t1, t2, t3])
+    keys = set(grouped.keys())
+    assert keys == {"c1", "c2"}
+    # placeholders should contain corresponding assignments
+    for k, v in grouped.items():
+        assert all(getattr(a, "comment_id", None) == k for a in v)
+
+
+def test_group_by_comment_and_characteristic_with_ids_and_objects():
+    now = datetime.utcnow()
+    t1 = TagAssignment(tagger_id="u1", comment_id="c1", characteristic_id="ch1", value=TagValue.YES, timestamp=now)
+    t2 = TagAssignment(tagger_id="u2", comment_id="c1", characteristic_id="ch2", value=TagValue.NO, timestamp=now)
+    # also a simple enriched object
+    c1 = Comment(id="c1", text="foo", prompt_id="p", tagassignments=[])
+    ch = Characteristic(id="ch1", name="ch1")
+    a3 = make_assignment(comment=c1, characteristic=ch, comment_id="c1", characteristic_id="ch1")
+
+    grouped = group_by_comment_and_characteristic([t1, t2, a3])
+    assert len(grouped) >= 2
+    # keys should be tuples of (comment_id, characteristic_id) strings
+    for (comment_id, characteristic_id), items in grouped.items():
+        assert isinstance(comment_id, str)
+        assert isinstance(characteristic_id, str)
+
+
+def test_taggers_who_touched_comment_supports_ids_and_objects():
+    now = datetime.utcnow()
+    ta1 = TagAssignment(tagger_id="u1", comment_id="c1", characteristic_id="ch", value=TagValue.YES, timestamp=now)
+    ta2 = TagAssignment(tagger_id="u2", comment_id="c1", characteristic_id="ch", value=TagValue.NO, timestamp=now)
+    # create an assignment with a Tagger object directly
+    t = Tagger(id="u3", tagassignments=[])
+    enriched = make_assignment(tagger=t, tagger_id="u3")
+
+    seen = taggers_who_touched_comment([ta1, ta2, enriched])
+    assert isinstance(seen, set)
+    assert seen == {"u1", "u2", "u3"}
+
+
+def test_count_yes_no_counts_only_yes_no():
+    now = datetime.utcnow()
+    a_yes = TagAssignment(tagger_id="u1", comment_id="c", characteristic_id="ch", value=TagValue.YES, timestamp=now)
+    a_no = TagAssignment(tagger_id="u2", comment_id="c", characteristic_id="ch", value=TagValue.NO, timestamp=now)
+    a_na = TagAssignment(tagger_id="u3", comment_id="c", characteristic_id="ch", value=TagValue.NA, timestamp=now)
+
+    yes, no = count_yes_no([a_yes, a_no, a_na])
+    assert yes == 1 and no == 1
+
+
+def test_alpha_for_item_returns_none_for_one_tagger_and_value_for_two():
+    now = datetime.utcnow()
+    # Single tagger => None
+    a1 = TagAssignment(tagger_id="u1", comment_id="c1", characteristic_id="ch", value=TagValue.YES, timestamp=now)
+    c = Characteristic(id="ch", name="ch")
+    assert alpha_for_item([a1], c) is None
+
+    # Two taggers agreeing => alpha should be defined (non-None, expected 1.0)
+    a2 = TagAssignment(tagger_id="u2", comment_id="c1", characteristic_id="ch", value=TagValue.YES, timestamp=now)
+    val = alpha_for_item([a1, a2], c)
+    assert isinstance(val, float)
+    # In the simple same-value case alpha is 1.0 per the algorithm
+    assert val == 1.0


### PR DESCRIPTION
# Add tag-level report helper utilities (ID-based grouping, counts, alpha wrapper)

## Summary
This PR adds the foundational helper utilities required for generating the Tag Report.  
These functions operate on `TagAssignment` objects and provide grouping, counting, and  
per-item agreement metrics that higher-level components will build on.

## What’s Included
**New file:** `src/qcc/reports/tag_report.py`

This module introduces:

- `TagReportRow` dataclass  
  - Holds fields needed for a (comment, characteristic) tag report row  
- `group_by_comment(assignments)`  
  - Groups assignments by `comment_id` (string-based)  
- `group_by_comment_and_characteristic(assignments)`  
  - Groups by `(comment_id, characteristic_id)`  
- `taggers_who_touched_comment(assignments)`  
  - Returns a `Set[str]` of tagger IDs that tagged the comment  
- `count_yes_no(assignments)`  
  - Counts YES/NO labels only (ignores NA)  
- `alpha_for_item(assignments, characteristic)`  
  - Wrapper around `AgreementMetrics.krippendorffs_alpha`  
  - Returns `None` if fewer than two distinct taggers participated

## Key Notes
- All grouping is **ID-based** to keep logic simple and avoid domain-object hashability issues.  
- This file includes **no CSV or high-level reporting logic** — only core helpers.  
- Serves as the foundation for the upcoming Tag Report builder and reliability integration.

## Tests
**New file:** `tests/test_reports_tag_report.py`

The test suite verifies:
- Grouping behavior for comments and characteristics  
- YES/NO counting  
- Tagger detection via IDs  
- Krippendorff’s alpha wrapper logic (edge cases included)

All tests pass.

