### PR TITLE
Refactor tag report helpers: grouping, agreement metrics, and removal of row structure

### DIFF
--- a/src/qcc/reports/tag_report.py
+++ b/src/qcc/reports/tag_report.py
@@ -1,54 +1,49 @@
 """Core utilities for tag-level reports.
 
-This module provides lightweight helper functions and a simple
-dataclass used by higher-level tag reporting tools.  It intentionally
-contains no I/O or CSV/export logic — those live in higher layers
-of the reporting system.
+This module provides lightweight helper functions for grouping and
+analyzing tag assignments. It intentionally contains no I/O or
+CSV/export logic — those live in higher layers of the reporting system.
 """
 
-from __future__ import annotations
+from __future__ import annotations  # future annotations
 
-from collections import defaultdict
-from dataclasses import dataclass
-from typing import Dict, List, Tuple, Set, Optional
+from collections import defaultdict  # dict grouping
+from typing import Dict, List, Tuple, Set, Optional  # type hints
 
-from qcc.domain.tagassignment import TagAssignment
-from qcc.domain.characteristic import Characteristic
-from qcc.domain.enums import TagValue
-from qcc.metrics.agreement import AgreementMetrics
+from qcc.domain.tagassignment import TagAssignment  # import assignments
+from qcc.domain.characteristic import Characteristic  # import characteristic
+from qcc.domain.enums import TagValue  # import tag values
+from qcc.metrics.agreement import AgreementMetrics  # import metrics
 
+# NOTE:
+# This module provides compute-only helper functions for tag-level reporting.
+# It intentionally does NOT define a row data structure or perform any I/O.
+# Higher-level report generators are expected to:
+# - call these helpers to compute values
+# - write results directly to their chosen output stream (CSV, JSON, etc.)
 
-@dataclass
-class TagReportRow:
-    comment_id: str
-    characteristic_id: str
-    num_taggers_could_set: int
-    num_yes: int
-    num_no: int
-    krippendorffs_alpha: Optional[float]
-    tag_quality: Optional[float] = None   # filled later by another component
 
 
 def group_by_comment(assignments: List[TagAssignment]) -> Dict[str, List[TagAssignment]]:
     """Group assignments by comment_id (string key).
 
     This function focuses on IDs only — it will look for a ``comment_id``
-    attribute on the assignment and fall back to an enriched ``comment.id``
-    when available. Assignments missing any comment id are skipped.
-    """
+    attribute on the assignment and fall back to assignment.comment.id if a comment object is present. 
+    Assignments missing any comment id are skipped.
+    """  # fixed incomplete docstring
 
-    groups: Dict[str, List[TagAssignment]] = defaultdict(list)
+    groups: Dict[str, List[TagAssignment]] = defaultdict(list)  # init grouping dict
 
-    for assignment in assignments or []:
-        cid = getattr(assignment, "comment_id", None)
-        if cid is None:
-            comment_obj = getattr(assignment, "comment", None)
-            cid = getattr(comment_obj, "id", None) if comment_obj is not None else None
-        if cid is None:
-            continue
-        groups[str(cid)].append(assignment)
+    for assignment in assignments or []:  # iterate assignments
+        cid = getattr(assignment, "comment_id", None)  # try direct comment_id
+        if cid is None:  # not found directly
+            comment_obj = getattr(assignment, "comment", None)  # get attached comment
+            cid = getattr(comment_obj, "id", None) if comment_obj is not None else None  # fallback to attached id
+        if cid is None:  # skip if still missing
+            continue  # skip this assignment
+        groups[str(cid)].append(assignment)  # add to group
 
-    return dict(groups)
+    return dict(groups)  # convert to dict
 
 
 def group_by_comment_and_characteristic(
@@ -61,24 +56,24 @@ def group_by_comment_and_characteristic(
     skipped.
     """
 
-    groups: Dict[Tuple[str, str], List[TagAssignment]] = defaultdict(list)
+    groups: Dict[Tuple[str, str], List[TagAssignment]] = defaultdict(list)  # init grouping dict
 
-    for assignment in assignments or []:
-        cid = getattr(assignment, "comment_id", None)
-        if cid is None:
-            comment_obj = getattr(assignment, "comment", None)
-            cid = getattr(comment_obj, "id", None) if comment_obj is not None else None
-        char_id = getattr(assignment, "characteristic_id", None)
-        if char_id is None:
-            char_obj = getattr(assignment, "characteristic", None)
-            char_id = getattr(char_obj, "id", None) if char_obj is not None else None
+    for assignment in assignments or []:  # iterate assignments
+        cid = getattr(assignment, "comment_id", None)  # try direct comment_id
+        if cid is None:  # not found directly
+            comment_obj = getattr(assignment, "comment", None)  # get attached comment
+            cid = getattr(comment_obj, "id", None) if comment_obj is not None else None  # fallback to attached id
+        char_id = getattr(assignment, "characteristic_id", None)  # try direct characteristic_id
+        if char_id is None:  # not found directly
+            char_obj = getattr(assignment, "characteristic", None)  # get attached characteristic
+            char_id = getattr(char_obj, "id", None) if char_obj is not None else None  # fallback to attached id
 
-        if cid is None or char_id is None:
-            continue
+        if cid is None or char_id is None:  # skip if either is missing
+            continue  # skip this assignment
 
-        groups[(str(cid), str(char_id))].append(assignment)
+        groups[(str(cid), str(char_id))].append(assignment)  # add to group
 
-    return dict(groups)
+    return dict(groups)  # convert to dict
 
 
 def taggers_who_touched_comment(assignments_for_comment: List[TagAssignment]) -> Set[str]:
@@ -88,16 +83,16 @@ def taggers_who_touched_comment(assignments_for_comment: List[TagAssignment]) ->
     Tagger objects.
     """
 
-    tagger_ids: Set[str] = set()
-    for assignment in assignments_for_comment or []:
-        tid = getattr(assignment, "tagger_id", None)
-        if tid is None:
-            tagger_obj = getattr(assignment, "tagger", None)
-            tid = getattr(tagger_obj, "id", None) if tagger_obj is not None else None
-        if tid is not None:
-            tagger_ids.add(str(tid))
+    tagger_ids: Set[str] = set()  # init tagger id set
+    for assignment in assignments_for_comment or []:  # iterate assignments
+        tid = getattr(assignment, "tagger_id", None)  # try direct tagger_id
+        if tid is None:  # not found directly
+            tagger_obj = getattr(assignment, "tagger", None)  # get attached tagger
+            tid = getattr(tagger_obj, "id", None) if tagger_obj is not None else None  # fallback to attached id
+        if tid is not None:  # if tagger id found
+            tagger_ids.add(str(tid))  # add to set
 
-    return tagger_ids
+    return tagger_ids  # return collected ids
 
 
 def count_yes_no(assignments: List[TagAssignment]) -> Tuple[int, int]:
@@ -106,17 +101,17 @@ def count_yes_no(assignments: List[TagAssignment]) -> Tuple[int, int]:
     Non-YES/NO values are ignored.
     """
 
-    yes = 0
-    no = 0
+    yes = 0  # init yes count
+    no = 0  # init no count
 
-    for assignment in assignments or []:
-        v = getattr(assignment, "value", None)
-        if v == TagValue.YES:
-            yes += 1
-        elif v == TagValue.NO:
-            no += 1
+    for assignment in assignments or []:  # iterate assignments
+        v = getattr(assignment, "value", None)  # get tag value
+        if v == TagValue.YES:  # check if yes
+            yes += 1  # increment yes
+        elif v == TagValue.NO:  # check if no
+            no += 1  # increment no
 
-    return yes, no
+    return yes, no  # return counts
 
 
 def alpha_for_item(assignments: List[TagAssignment], characteristic: Characteristic) -> Optional[float]:
@@ -127,13 +122,12 @@ def alpha_for_item(assignments: List[TagAssignment], characteristic: Characteris
     to signify alpha is not defined.
     """
 
-    if not assignments:
-        return None
+    if not assignments:  # check if empty
+        return None  # no data
 
-    # If fewer than 2 unique taggers, alpha is not meaningful
-    taggers = taggers_who_touched_comment(assignments)
-    if len(taggers) < 2:
-        return None
+    taggers = taggers_who_touched_comment(assignments)  # get tagger ids
+    if len(taggers) < 2:  # need at least 2 taggers
+        return None  # alpha undefined
 
-    metrics = AgreementMetrics()
-    return metrics.krippendorffs_alpha(assignments, characteristic)
+    metrics = AgreementMetrics()  # create metrics calculator
+    return metrics.krippendorffs_alpha(assignments, characteristic)  # compute alpha

--- a/src/qcc/reports/tag_report.py
+++ b/src/qcc/reports/tag_report.py
@@ -13,7 +13,7 @@ from typing import Dict, List, Tuple, Set, Optional  # type hints
 from qcc.domain.tagassignment import TagAssignment  # import assignments
 from qcc.domain.characteristic import Characteristic  # import characteristic
 from qcc.domain.enums import TagValue  # import tag values
-from qcc.metrics.agreement import AgreementMetrics  # import metrics
+from qcc.metrics.agreement import AgreementMetrics, LatestLabelPercentAgreement  # add import
 
 # NOTE:
 # This module provides compute-only helper functions for tag-level reporting.
@@ -131,3 +131,47 @@ def alpha_for_item(assignments: List[TagAssignment], characteristic: Characteris
 
     metrics = AgreementMetrics()  # create metrics calculator
     return metrics.krippendorffs_alpha(assignments, characteristic)  # compute alpha
+
+
+def percent_agreement_for_item(assignments: List[TagAssignment], characteristic: Characteristic) -> Optional[float]:  # new helper
+    """Return percent agreement for a single (comment, characteristic).
+
+    Uses LatestLabelPercentAgreement to compute percent agreement and
+    returns a value rounded to 3 decimals and clamped to [0.0, 1.0].
+    """  # docstring for percent agreement
+
+    if not assignments:  # return None if empty
+        return None  # empty fallback
+
+    taggers = taggers_who_touched_comment(assignments)  # get unique taggers
+    if len(taggers) < 2:  # need at least two taggers
+        return None  # not enough taggers
+
+    pla = LatestLabelPercentAgreement()  # create percent-agreement calculator
+    pa = pla.percent_agreement(assignments, characteristic)  # compute percent agreement
+    # clamp to [0.0, 1.0]
+    if pa is None:  # handle None result
+        return None  # propagate None
+    pa_clamped = max(0.0, min(1.0, float(pa)))  # clamp value
+    return round(pa_clamped, 3)  # round and return
+
+
+def cohens_kappa_for_item(assignments: List[TagAssignment], characteristic: Characteristic) -> Optional[float]:  # new helper
+    """Return Cohen's kappa for a single (comment, characteristic).
+
+    Uses LatestLabelPercentAgreement to compute Cohen's kappa and returns
+    a value rounded to 3 decimals (no clamping).
+    """  # docstring for kappa
+
+    if not assignments:  # return None if empty
+        return None  # empty fallback
+
+    taggers = taggers_who_touched_comment(assignments)  # get unique taggers
+    if len(taggers) < 2:  # need at least two taggers
+        return None  # not enough taggers
+
+    pla = LatestLabelPercentAgreement()  # create percent-agreement calculator
+    k = pla.cohens_kappa(assignments, characteristic)  # compute kappa
+    if k is None:  # handle None result
+        return None  # propagate None
+    return round(float(k), 3)  # round and return

--- a/src/qcc/reports/tag_report.py
+++ b/src/qcc/reports/tag_report.py
@@ -24,13 +24,13 @@ from qcc.metrics.agreement import AgreementMetrics, LatestLabelPercentAgreement 
 
 
 
-def group_by_comment(assignments: List[TagAssignment]) -> Dict[str, List[TagAssignment]]:
+def group_by_comment(assignments: List[TagAssignment]) -> Dict[str, List[TagAssignment]]:  # function header
     """Group assignments by comment_id (string key).
 
-    This function focuses on IDs only — it will look for a ``comment_id``
-    attribute on the assignment and fall back to assignment.comment.id if a comment object is present. 
-    Assignments missing any comment id are skipped.
-    """  # fixed incomplete docstring
+    This function reads the comment id from `assignment.comment_id` or, if
+    that is missing, falls back to the attached object's `assignment.comment.id`.
+    Assignments missing both are skipped.
+    """  # updated docstring
 
     groups: Dict[str, List[TagAssignment]] = defaultdict(list)  # init grouping dict
 
@@ -48,13 +48,14 @@ def group_by_comment(assignments: List[TagAssignment]) -> Dict[str, List[TagAssi
 
 def group_by_comment_and_characteristic(
     assignments: List[TagAssignment],
-) -> Dict[Tuple[str, str], List[TagAssignment]]:
+) -> Dict[Tuple[str, str], List[TagAssignment]]:  # function header
     """Group assignments by (comment_id, characteristic_id) tuple of strings.
 
-    This is explicitly ID-focused and does not attempt to create any
-    placeholder domain objects. If either id is missing the assignment is
-    skipped.
-    """
+    This function reads `assignment.comment_id` or falls back to the
+    attached object's `assignment.comment.id`, and reads
+    `assignment.characteristic_id` or falls back to
+    `assignment.characteristic.id`. Assignments missing either id are skipped.
+    """  # updated docstring
 
     groups: Dict[Tuple[str, str], List[TagAssignment]] = defaultdict(list)  # init grouping dict
 
@@ -76,12 +77,12 @@ def group_by_comment_and_characteristic(
     return dict(groups)  # convert to dict
 
 
-def taggers_who_touched_comment(assignments_for_comment: List[TagAssignment]) -> Set[str]:
-    """Return set of tagger_id strings of taggers who tagged this comment.
+def taggers_who_touched_comment(assignments_for_comment: List[TagAssignment]) -> Set[str]:  # function header
+    """Return set of tagger id strings for these assignments.
 
-    This function strictly returns IDs and does not construct or return
-    Tagger objects.
-    """
+    Reads `assignment.tagger_id` or, if missing, falls back to the attached object's
+    `assignment.tagger.id`. Missing ids are skipped.
+    """ 
 
     tagger_ids: Set[str] = set()  # init tagger id set
     for assignment in assignments_for_comment or []:  # iterate assignments
@@ -95,11 +96,14 @@ def taggers_who_touched_comment(assignments_for_comment: List[TagAssignment]) ->
     return tagger_ids  # return collected ids
 
 
-def count_yes_no(assignments: List[TagAssignment]) -> Tuple[int, int]:
-    """Return (#YES, #NO) based on TagValue.YES and TagValue.NO.
 
-    Non-YES/NO values are ignored.
-    """
+
+
+def count_yes_no(assignments: List[TagAssignment]) -> Tuple[int, int]:
+    """Return (#YES votes, #NO votes) for these assignments.
+
+    Only counts TagValue.YES and TagValue.NO. Other values are ignored.
+    """ 
 
     yes = 0  # init yes count
     no = 0  # init no count
@@ -160,7 +164,7 @@ def cohens_kappa_for_item(assignments: List[TagAssignment], characteristic: Char
     """Return Cohen's kappa for a single (comment, characteristic).
 
     Uses LatestLabelPercentAgreement to compute Cohen's kappa and returns
-    a value rounded to 3 decimals (no clamping).
+    a value rounded to 3 decimals.
     """  # docstring for kappa
 
     if not assignments:  # return None if empty
@@ -170,7 +174,7 @@ def cohens_kappa_for_item(assignments: List[TagAssignment], characteristic: Char
     if len(taggers) < 2:  # need at least two taggers
         return None  # not enough taggers
 
-    pla = LatestLabelPercentAgreement()  # create percent-agreement calculator
+    pla = LatestLabelPercentAgreement()  # create agreement calculator
     k = pla.cohens_kappa(assignments, characteristic)  # compute kappa
     if k is None:  # handle None result
         return None  # propagate None

--- a/tests/test_reports_tag_report.py
+++ b/tests/test_reports_tag_report.py
@@ -9,7 +9,6 @@ from qcc.reports.tag_report import (
     taggers_who_touched_comment,
     count_yes_no,
     alpha_for_item,
-    TagReportRow,
 )
 from qcc.domain.comment import Comment
 from qcc.domain.characteristic import Characteristic


### PR DESCRIPTION
## Refactor tag report helpers: grouping, agreement metrics, and removal of row structure

### Summary
This PR refactors the tag report helper utilities to align with the intended end-of-semester architecture:
- helpers are **compute-only**
- no row data structures are created
- agreement logic is centralized and reused
- naming and documentation are clarified for review

These changes keep behavior correct while making the reporting pipeline easier to reason about and integrate at a higher level.

---

### Key Changes

#### 1. Removed `TagReportRow` dataclass
- Deleted the `TagReportRow` structure from `tag_report.py`
- Helpers now compute values only; no row objects are created
- Higher-level report generators are expected to write directly to their chosen output streams (CSV, JSON, etc.)

This avoids premature data modeling and keeps responsibilities separated.

---

#### 2. Clarified grouping helpers and ID fallback behavior
- `group_by_comment`
- `group_by_comment_and_characteristic`
- `taggers_who_touched_comment`

Docstrings now explicitly document ID resolution:
- `assignment.comment_id` → fallback `assignment.comment.id`
- `assignment.characteristic_id` → fallback `assignment.characteristic.id`
- `assignment.tagger_id` → fallback `assignment.tagger.id`

No behavior changes were made.

---

#### 3. Added agreement helpers using existing implementation
New helper functions added:
- `percent_agreement_for_item(...)`
- `cohens_kappa_for_item(...)`

These delegate to `LatestLabelPercentAgreement` and:
- return `None` if fewer than two taggers are present
- round results to 3 decimals
- clamp percent agreement to `[0.0, 1.0]`

This avoids reimplementing agreement logic and ensures consistency across metrics.

---

#### 4. Improved naming clarity without breaking compatibility
- Ambiguous wording in docstrings was cleaned up
- “enriched” was replaced with explicit “attached object fallback” language
- Existing function names were preserved to avoid breaking callers

---

### Scope Notes
- This PR intentionally does **not** modify report generation or output wiring
- Integration into CSV/JSON streams is expected to be handled by higher-level reporting code
- All changes are limited to helper-level logic and documentation

---

### Testing
- Existing helper behavior remains unchanged
- File compiles cleanly
- No report-generation tests were modified as output logic is out of scope

---

### Rationale
These changes reflect the project’s current stage:
- helpers should be small, explicit, and reusable
- agreement logic should not be duplicated
- integration should happen where full context exists

This keeps the codebase stable while allowing downstream integration work to proceed cleanly.
